### PR TITLE
ConfigurationWrapper constructor brought back from 7.7.2

### DIFF
--- a/language/src/main/java/de/monticore/lang/sysmlv2/symboltable/adapters/ConfigurationWrapper.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/symboltable/adapters/ConfigurationWrapper.java
@@ -37,6 +37,9 @@ import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+
 public class ConfigurationWrapper implements ASTConfiguration {
   private final ISysMLv2Scope enclosingScope;
 
@@ -67,12 +70,13 @@ public class ConfigurationWrapper implements ASTConfiguration {
     this.state = new StateWrapper(state, assignments);
   }
 
-  public ConfigurationWrapper(ASTExpression stateExpression) {
-    this(stateExpression, null);
-  }
-
-  public ConfigurationWrapper(String state) {
-    this(state, null);
+  public ConfigurationWrapper(
+      String state,
+      ISysMLv2Scope enclosingScope)
+  {
+    this.enclosingScope = enclosingScope;
+    this.outputs = emptyList();
+    this.state = new StateWrapper(state, emptyMap());
   }
 
   public ConfigurationWrapper(ASTExpression state, ASTActionUsage adaptee) {

--- a/language/src/main/java/de/monticore/lang/sysmlv2/symboltable/adapters/StateUsage2AutomatonAdapter.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/symboltable/adapters/StateUsage2AutomatonAdapter.java
@@ -44,7 +44,9 @@ public class StateUsage2AutomatonAdapter extends AutomatonSymbol {
           initialConfiguration.add(new ConfigurationWrapper(initialState, entry.getActionUsage()));
         }
         else {
-          initialConfiguration.add(new ConfigurationWrapper(initialState));
+          initialConfiguration.add(
+              new ConfigurationWrapper(initialState,
+                  (ISysMLv2Scope) entry.getEnclosingScope()));
         }
       }
 

--- a/language/src/main/java/de/monticore/lang/sysmlv2/symboltable/adapters/TransitionWrapper.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/symboltable/adapters/TransitionWrapper.java
@@ -10,6 +10,7 @@ import de.monticore.lang.componentconnector._ast.ASTTransition;
 import de.monticore.lang.componentconnector._symboltable.IComponentConnectorScope;
 import de.monticore.lang.componentconnector._visitor.ComponentConnectorTraverser;
 import de.monticore.lang.sysmlstates._ast.ASTSysMLTransition;
+import de.monticore.lang.sysmlv2._symboltable.ISysMLv2Scope;
 import de.monticore.literals.mccommonliterals._ast.ASTBooleanLiteralBuilder;
 import de.monticore.literals.mccommonliterals._ast.ASTConstantsMCCommonLiterals;
 import de.monticore.literals.mccommonliterals._symboltable.IMCCommonLiteralsScope;
@@ -66,7 +67,7 @@ public class TransitionWrapper implements ASTTransition {
       result = new ConfigurationWrapper(adaptee.getSuccessionThen().getMCQualifiedName().getQName(), adaptee.getDoAction());
     }
     else {
-      result = new ConfigurationWrapper(adaptee.getSuccessionThen().getMCQualifiedName().getQName());
+      result = new ConfigurationWrapper(adaptee.getSuccessionThen().getMCQualifiedName().getQName(), (ISysMLv2Scope) adaptee.getEnclosingScope());
     }
   }
 


### PR DESCRIPTION
this(state, null) verursacht eine NullPointerException, deswegen habe ich den Konstruktor aus Version 7.7.2 wiederhergestellt. Mit diesen Ängerungen funktioniert der InverterTest in sysmltransformer.