### PR TITLE
fix: don't load model from .sym file if subscope already exists

### DIFF
--- a/language/src/main/java/de/monticore/lang/sysmlv2/_symboltable/SysMLv2GlobalScope.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/_symboltable/SysMLv2GlobalScope.java
@@ -32,7 +32,11 @@ public class SysMLv2GlobalScope extends SysMLv2GlobalScopeTOP {
       throw new RuntimeException(e);
      }*/
 
-    if (location.isPresent() && !this.isFileLoaded((location.get()).toString())) {
+    if (
+        location.isPresent() &&
+        !this.isFileLoaded((location.get()).toString()) &&
+        !subScopes.stream().anyMatch(scope -> scope.getName().equals(modelName))
+    ) {
       this.addLoadedFile((location.get()).toString());
 
       ISysMLv2ArtifactScope as = getSymbols2Json().load(location.get());


### PR DESCRIPTION
Modelle werden von den .sym Dateien nicht geladen, wenn das Modell schon geladen wurde.