### PR TITLE
Forwardporting "Replace AST-Access by Symbol-Access for hasCardinality()" (#84)

### DIFF
--- a/language/src/main/java/de/monticore/lang/sysmlparts/_symboltable/PortUsageSymbol.java
+++ b/language/src/main/java/de/monticore/lang/sysmlparts/_symboltable/PortUsageSymbol.java
@@ -10,6 +10,8 @@ import java.util.stream.Collectors;
 
 public class PortUsageSymbol extends PortUsageSymbolTOP {
 
+  private boolean hasCardinality;
+
   public PortUsageSymbol(String name) {
     super(name);
   }
@@ -110,6 +112,14 @@ public class PortUsageSymbol extends PortUsageSymbolTOP {
     );
 
     return res;
+  }
+
+  public boolean hasCardinality() {
+    return this.hasCardinality;
+  }
+
+  public void setHasCardinality(boolean hasCardinality) {
+    this.hasCardinality = hasCardinality;
   }
 
   /**

--- a/language/src/main/java/de/monticore/lang/sysmlparts/symboltable/completers/SysMLPartsCompleter.java
+++ b/language/src/main/java/de/monticore/lang/sysmlparts/symboltable/completers/SysMLPartsCompleter.java
@@ -1,0 +1,11 @@
+package de.monticore.lang.sysmlparts.symboltable.completers;
+
+import de.monticore.lang.sysmlparts._ast.ASTPortUsage;
+import de.monticore.lang.sysmlparts._visitor.SysMLPartsVisitor2;
+
+public class SysMLPartsCompleter implements SysMLPartsVisitor2 {
+
+  public void visit(ASTPortUsage node) {
+    node.getSymbol().setHasCardinality(node.getCardinality().isPresent());
+  }
+}

--- a/language/src/main/java/de/monticore/lang/sysmlv2/SysMLv2Tool.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/SysMLv2Tool.java
@@ -12,6 +12,7 @@ import de.monticore.lang.sysmlparts.coco.PortDefHasOneType;
 import de.monticore.lang.sysmlparts.coco.PortDefNeedsDirection;
 import de.monticore.lang.sysmlparts.symboltable.completers.ConvertEnumUsagesToFields;
 import de.monticore.lang.sysmlconstraints._cocos.SysMLConstraintsASTRequirementDefCoCo;
+import de.monticore.lang.sysmlparts.symboltable.completers.SysMLPartsCompleter;
 import de.monticore.lang.sysmlstates._cocos.SysMLStatesASTStateDefCoCo;
 import de.monticore.lang.sysmlstates._cocos.SysMLStatesASTStateUsageCoCo;
 import de.monticore.lang.sysmlstates.cocos.NoDoActions;
@@ -200,6 +201,7 @@ public class SysMLv2Tool extends SysMLv2ToolTOP {
     traverser.add4SysMLBasis(new DirectionCompleter());
     traverser.add4SysMLParts(new DirectionCompleter());
     traverser.add4SysMLParts(new ConvertEnumUsagesToFields());
+    traverser.add4SysMLParts(new SysMLPartsCompleter());
     traverser.add4SysMLParts(new IdentifierCompletion());
 
     // Visiting artifact scope _and_ the AST requires two calls

--- a/language/src/main/java/de/monticore/lang/sysmlv2/_symboltable/ISysMLv2Scope.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/_symboltable/ISysMLv2Scope.java
@@ -105,7 +105,7 @@ public interface ISysMLv2Scope extends ISysMLv2ScopeTOP {
         // we omit to set the ASTNode
         var variable = new PortUsage2VariableSymbolAdapter(portUsage);
 
-        if (portUsage.getAstNode().getCardinality().isPresent()) {
+        if (portUsage.hasCardinality()) {
           variable.setType(SymTypeExpressionFactory.createTypeArray(resolved, 1,
               SymTypeExpressionFactory.createTypeObject(resolved)));
         }


### PR DESCRIPTION
## Changed

* When resolving for adapted variables, ports may have a cardinality and thus be of array type. Previously, the check for cardinalities relied on the AST, which breaks if the symbol is loaded from a serialized symbol table. This change replaces the access to the AST with a newly introduced field on the symbol (and also adds the symbol table completer). This is a forward port from https://github.com/MontiCore/sysmlv2/pull/84