### PR TITLE
7.8.31 Extending CC-Requirement-Symbol by invariant and subject fields

### DIFF
--- a/cc/src/main/grammars/de/monticore/lang/ComponentConnector.mc4
+++ b/cc/src/main/grammars/de/monticore/lang/ComponentConnector.mc4
@@ -168,6 +168,8 @@ component grammar ComponentConnector
    ;
 
    symbolrule Requirement =
+      stateInvariant: boolean
+      subject:MildComponentSymbol
       assumptions:Expression*
       guarantee:Expression
    ;

--- a/cc/src/main/java/de/monticore/lang/componentconnector/_symboltable/RequirementSymbolDeSer.java
+++ b/cc/src/main/java/de/monticore/lang/componentconnector/_symboltable/RequirementSymbolDeSer.java
@@ -8,6 +8,12 @@ import java.util.List;
 public class RequirementSymbolDeSer extends RequirementSymbolDeSerTOP {
 
   @Override
+  protected void serializeSubject(MildComponentSymbol subject,
+                                  ComponentConnectorSymbols2Json s2j) {
+    // not implemented
+  }
+
+  @Override
   protected void serializeAssumptions(List<ASTExpression> assumptions,
                                       ComponentConnectorSymbols2Json s2j) {
     // not implemented
@@ -17,6 +23,12 @@ public class RequirementSymbolDeSer extends RequirementSymbolDeSerTOP {
   protected void serializeGuarantee(ASTExpression guarantee,
                                     ComponentConnectorSymbols2Json s2j) {
     // not implemented
+  }
+
+  @Override
+  protected MildComponentSymbol deserializeSubject(JsonObject symbolJson) {
+    // not implemented
+    return null;
   }
 
   @Override

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,4 +25,4 @@ assertj_version    = 3.21.0
 junit_version      = 5.8.2
 
 # Version of published artifacts
-version            = 7.8.30
+version            = 7.8.31


### PR DESCRIPTION
## Added

* Symbolrule: Flag to distinguish state constraints from history constraints on Component-Connector Requirement Symbol
* Symbolrule: Subject on Component-Connector Requirement Symbol