### PR TITLE
Forwardport:: Extending CC-RequirementSymbol by invariant an…

### DIFF
--- a/cc/src/main/grammars/de/monticore/lang/ComponentConnector.mc4
+++ b/cc/src/main/grammars/de/monticore/lang/ComponentConnector.mc4
@@ -159,6 +159,19 @@ component grammar ComponentConnector
   /**
    * Requirements: Wir berücksichtigen primär die Namen der Requirements
    */
-   interface symbol Requirement = Name;
+   interface symbol Requirement =
+     name:Name
+     [isStateInvariant:"invariant"]?
+     subject:MildComponent
+     assumptions:Expression*
+     guarantee:Expression
+   ;
+
+   symbolrule Requirement =
+      stateInvariant: boolean
+      subject:MildComponentSymbol
+      assumptions:Expression*
+      guarantee:Expression
+   ;
 
 }

--- a/cc/src/main/java/de/monticore/lang/componentconnector/_symboltable/RequirementSymbolDeSer.java
+++ b/cc/src/main/java/de/monticore/lang/componentconnector/_symboltable/RequirementSymbolDeSer.java
@@ -1,0 +1,45 @@
+package de.monticore.lang.componentconnector._symboltable;
+
+import de.monticore.expressions.expressionsbasis._ast.ASTExpression;
+import de.monticore.symboltable.serialization.json.JsonObject;
+
+import java.util.List;
+
+public class RequirementSymbolDeSer extends RequirementSymbolDeSerTOP {
+
+  @Override
+  protected void serializeSubject(MildComponentSymbol subject,
+                                  ComponentConnectorSymbols2Json s2j) {
+    // not implemented
+  }
+
+  @Override
+  protected void serializeAssumptions(List<ASTExpression> assumptions,
+                                      ComponentConnectorSymbols2Json s2j) {
+    // not implemented
+  }
+
+  @Override
+  protected void serializeGuarantee(ASTExpression guarantee,
+                                    ComponentConnectorSymbols2Json s2j) {
+    // not implemented
+  }
+
+  @Override
+  protected MildComponentSymbol deserializeSubject(JsonObject symbolJson) {
+    // not implemented
+    return null;
+  }
+
+  @Override
+  protected List<ASTExpression> deserializeAssumptions(JsonObject symbolJson) {
+    // not implemented
+    return List.of();
+  }
+
+  @Override
+  protected ASTExpression deserializeGuarantee(JsonObject symbolJson) {
+    // not implemented
+    return null;
+  }
+}


### PR DESCRIPTION
## Added
* Forwardporting: Added Fields 'name', 'invariant', 'subject', 'assumptions', 'guarantee' for ComponentConnectors Requirement, field