### PR TITLE
7.8.35: Support "#refinement dependency to Y" syntax in part definitions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,4 +25,4 @@ assertj_version    = 3.21.0
 junit_version      = 5.8.2
 
 # Version of published artifacts
-version            = 7.8.34
+version            = 7.8.35

--- a/language/src/main/grammars/de/monticore/lang/SysMLBasis.mc4
+++ b/language/src/main/grammars/de/monticore/lang/SysMLBasis.mc4
@@ -284,7 +284,7 @@ component grammar SysMLBasis
   interface IInlineOccurrenceUsage ;
 
   Dependency implements SysMLElement =
-    Modifier UserDefinedKeyword* "dependency" (Name? "from")? (MCQualifiedName || ",")+ "to" (MCQualifiedName || ",")+
+    Modifier UserDefinedKeyword* "dependency" (Name? "from")? sources:(MCQualifiedName || ",")* "to" targets:(MCQualifiedName || ",")+
     ("{"
        SysMLElement*
      "}" | ";");

--- a/language/src/main/java/de/monticore/lang/sysmlbasis/_ast/ASTDependency.java
+++ b/language/src/main/java/de/monticore/lang/sysmlbasis/_ast/ASTDependency.java
@@ -1,0 +1,10 @@
+package de.monticore.lang.sysmlbasis._ast;
+
+public class ASTDependency extends ASTDependencyTOP {
+
+  public boolean isRefinementDependency() {
+    return getUserDefinedKeywordList().stream()
+        .map(keyword -> keyword.getMCQualifiedName().toString())
+        .anyMatch("refinement"::equals);
+  }
+}

--- a/language/src/main/java/de/monticore/lang/sysmlparts/_ast/ASTPartDef.java
+++ b/language/src/main/java/de/monticore/lang/sysmlparts/_ast/ASTPartDef.java
@@ -1,5 +1,6 @@
 package de.monticore.lang.sysmlparts._ast;
 
+import de.monticore.lang.sysmlbasis._ast.ASTDependency;
 import de.monticore.lang.sysmlbasis._ast.ASTSpecialization;
 import de.monticore.lang.sysmlbasis._ast.ASTSysMLElement;
 import de.monticore.lang.sysmlbasis._ast.ASTSysMLRefinement;
@@ -30,9 +31,19 @@ public class ASTPartDef extends ASTPartDefTOP {
         .collect(Collectors.toList());
   }
 
+  public List<ASTDependency> getRefinementDependencies() {
+    return getSysMLElements(ASTDependency.class).stream()
+        .filter(ASTDependency::isRefinementDependency)
+        .filter(dependency -> dependency.isEmptySources()
+            || dependency.getSourcesList().stream()
+            .map(Object::toString)
+            .anyMatch(this.getName()::equals))
+        .collect(Collectors.toList());
+  }
+
   /**
-   * Löst die als Specialization verpackten Refinement-Relationen auf. Ist dabei nicht transitiv, sondern rein AST-
-   * orientiert: Wenn etwas nicht explizit im AST steht, wird es auch nicht zurückgegeben.
+   * Löst Refinement-Relationen auf. Ist dabei nicht transitiv, sondern rein AST-orientiert: Wenn etwas nicht explizit
+   * im AST steht, wird es auch nicht zurückgegeben.
    */
   public List<PartDefSymbol> getRefinements() {
     List<PartDefSymbol> refinements = new ArrayList<>();
@@ -50,6 +61,16 @@ public class ASTPartDef extends ASTPartDefTOP {
         }
       }
     }
+
+    for (ASTDependency dependency : getRefinementDependencies()) {
+      dependency.getTargetsList().stream()
+          .map(Object::toString)
+          .map(name -> this.getEnclosingScope().resolvePartDef(name))
+          .filter(Optional::isPresent)
+          .map(Optional::get)
+          .forEach(refinements::add);
+    }
+
     return refinements;
   }
 

--- a/language/src/main/java/de/monticore/lang/sysmlv2/cocos/RefinementCyclic.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/cocos/RefinementCyclic.java
@@ -23,15 +23,19 @@ public class RefinementCyclic implements SysMLPartsASTPartDefCoCo {
     var refiners = node.getSymbol().getTransitiveRefiners();
     var refinements = node.getSymbol().getTransitiveRefinements();
 
-    var cyclicRefinements = refiners.stream().filter(refinements::contains).map(SysMLTypeSymbol::getName).collect(Collectors.toList());
-    var pos = node.getSpecializationList().stream()
-        .filter(s -> s instanceof ASTSysMLRefinement)
-        .map(ASTNode::get_SourcePositionStart)
-        .findFirst()
-        .orElse(node.get_SourcePositionStart());
+    var cyclicRefinements = refiners.stream().filter(refinements::contains)
+        .map(SysMLTypeSymbol::getName)
+        .collect(Collectors.toList());
+    var pos = node.get_SourcePositionStart();
 
     if (cyclicRefinements.size() > 0) {
-      Log.error("0x90030 Cyclic refinement detected: " + node.getName() + " <-> " + String.join(", ", cyclicRefinements), pos);
+      Log.error(
+          "0x90030 Cyclic refinement detected: "
+              + node.getName()
+              + " <-> "
+              + String.join(", ", cyclicRefinements),
+          pos
+      );
     }
 
     if (node.getRefinements().contains(node.getSymbol())) {

--- a/language/src/main/java/de/monticore/lang/sysmlv2/cocos/RefinementInterfaceNotMatching.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/cocos/RefinementInterfaceNotMatching.java
@@ -1,7 +1,5 @@
 package de.monticore.lang.sysmlv2.cocos;
 
-import de.monticore.ast.ASTNode;
-import de.monticore.lang.sysmlbasis._ast.ASTSysMLRefinement;
 import de.monticore.lang.sysmlparts._ast.ASTPartDef;
 import de.monticore.lang.sysmlparts._cocos.SysMLPartsASTPartDefCoCo;
 import de.se_rwth.commons.logging.Log;
@@ -25,14 +23,14 @@ public class RefinementInterfaceNotMatching implements SysMLPartsASTPartDefCoCo 
         .collect(Collectors.toList());
 
     if (notMatching.size() > 0) {
-      var pos = node.getSpecializationList().stream()
-          .filter(s -> s instanceof ASTSysMLRefinement)
-          .map(ASTNode::get_SourcePositionStart)
-          .findFirst()
-          .orElse(node.get_SourcePositionStart());
-
       for (var refinement : notMatching) {
-        Log.error("0x9004 Interface of refinement " + refinement.getName() + " is incompatible.", pos);
+        Log.error(
+            "0x9004 Interface of refinement "
+                + refinement.getName()
+                + " is incompatible.",
+            node.get_SourcePositionStart(),
+            node.get_SourcePositionEnd()
+        );
       }
     }
   }

--- a/language/src/main/java/de/monticore/lang/sysmlv2/cocos/RefinementTargetDefinitionExistsCoCo.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/cocos/RefinementTargetDefinitionExistsCoCo.java
@@ -9,9 +9,10 @@ import de.monticore.types.mcbasictypes._ast.ASTMCType;
 import de.se_rwth.commons.logging.Log;
 
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
- * CoCo2: Jeder im "part def X refines Name" verwendete Name muss eine existierende Part-Definition sein.
+ * CoCo2: Jeder in einer Refinement-Relation verwendete Name muss eine existierende Part-Definition sein.
  */
 public class RefinementTargetDefinitionExistsCoCo implements SysMLPartsASTPartDefCoCo {
 
@@ -21,17 +22,23 @@ public class RefinementTargetDefinitionExistsCoCo implements SysMLPartsASTPartDe
 
   @Override
   public void check(ASTPartDef node) {
-    var nonExistent = node.streamSpecializations()
+    var nonExistentSpecializations = node.streamSpecializations()
         .filter(s -> s instanceof ASTSysMLRefinement)
         .flatMap(ASTSpecialization::streamSuperTypes)
-        .filter(t ->
-            node.getEnclosingScope().resolvePartDef(printPartType(t)).isEmpty()
-        )
+        .map((ASTMCType t) -> t.printType())
+        .filter(name -> node.getEnclosingScope().resolvePartDef(name).isEmpty());
+
+    var nonExistentDependencies = node.getRefinementDependencies().stream()
+        .flatMap(dep -> dep.getTargetsList().stream())
+        .map(Object::toString)
+        .filter(name -> node.getEnclosingScope().resolvePartDef(name).isEmpty());
+
+    var nonExistent = Stream.concat(nonExistentSpecializations, nonExistentDependencies)
         .collect(Collectors.toList());
 
     for (var problem : nonExistent) {
       Log.error(
-          "0x10AA2 The name used in 'refines' \"" + printPartType(problem)
+          "0x10AA2 The name used in 'refines' \"" + problem
               + "\" does not exist as a part definition.",
           node.get_SourcePositionStart(),
           node.get_SourcePositionEnd()

--- a/language/src/main/java/de/monticore/lang/sysmlv2/symboltable/completers/DirectRefinementCompleter.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/symboltable/completers/DirectRefinementCompleter.java
@@ -7,7 +7,7 @@ import de.monticore.lang.sysmlparts._visitor.SysMLPartsVisitor2;
 import de.monticore.lang.sysmlv2.SysMLv2Mill;
 import de.monticore.lang.sysmlv2.types.SysMLSynthesizer;
 import de.monticore.types.check.SymTypeExpression;
-import de.monticore.types.check.TypeCheckResult;
+import de.monticore.types.check.SymTypeExpressionFactory;
 
 import java.util.ArrayList;
 import java.util.stream.Collectors;
@@ -29,25 +29,17 @@ public class DirectRefinementCompleter implements SysMLPartsVisitor2 {
         new ArrayList<SymTypeExpression>()
     );
 
-    var refinementTypes = node.getSpecializationList().stream()
-        .filter(r -> r instanceof ASTSysMLRefinement)
-        .flatMap(r -> r.getSuperTypesList().stream()).collect(Collectors.toList());
-
-    for (var refinementType : refinementTypes) {
-      // Check existence of refinement before actually synthesizing it to avoid
-      // FATAL errors thrown by the synthesizer
-     if (refinementType.getDefiningSymbol().isEmpty()) {
-       continue;
-     }
-      var result = syn.synthesizeType(refinementType);
-      if (result.isPresentResult()) {
-        node.getSymbol().addDirectRefinements(result.getResult());
-      }
-    }
+    node.getRefinements().stream()
+        .map(refinement -> SymTypeExpressionFactory.createTypeObject(
+            refinement.getFullName(),
+            node.getEnclosingScope()
+        ))
+        .forEach(node.getSymbol()::addDirectRefinements);
 
     var specializationTypes = node.getSpecializationList().stream()
         .filter(r -> r instanceof ASTSysMLSpecialization)
-        .flatMap(r -> r.getSuperTypesList().stream()).collect(Collectors.toList());
+        .flatMap(r -> r.getSuperTypesList().stream())
+        .collect(Collectors.toList());
 
     for (var specializationType : specializationTypes) {
       // Check existence of refinement before actually synthesizing it to avoid

--- a/language/src/test/java/astrules/ASTPartDefTest.java
+++ b/language/src/test/java/astrules/ASTPartDefTest.java
@@ -47,4 +47,24 @@ public class ASTPartDefTest {
     assertThat(C.getRefinements().get(1)).isEqualTo(B.getSymbol());
   }
 
+  @Test
+  public void test_getRefinements_dependencyBased() throws IOException {
+    Optional<ASTSysMLModel> ast = SysMLv2Mill.parser().parse_String(
+        "part def A; part def C; "
+            + "part def D { #refinement dependency to A; "
+            + "#refinement dependency to C; }");
+    assertThat(ast).isPresent();
+
+    SysMLv2Mill.scopesGenitorDelegator().createFromAST(ast.get());
+
+    ASTPartDef A = (ASTPartDef) ast.get().getSysMLElement(0);
+    ASTPartDef C = (ASTPartDef) ast.get().getSysMLElement(1);
+    ASTPartDef D = (ASTPartDef) ast.get().getSysMLElement(2);
+
+    // Dependency-based refinement
+    assertThat(D.getRefinements()).hasSize(2);
+    assertThat(D.getRefinements().get(0)).isEqualTo(A.getSymbol());
+    assertThat(D.getRefinements().get(1)).isEqualTo(C.getSymbol());
+  }
+
 }

--- a/language/src/test/java/cocos/RefinementTargetDefinitionExistsCoCoTest.java
+++ b/language/src/test/java/cocos/RefinementTargetDefinitionExistsCoCoTest.java
@@ -5,7 +5,6 @@ import de.monticore.lang.sysmlv2.SysMLv2Mill;
 import de.monticore.lang.sysmlv2.SysMLv2Tool;
 import de.monticore.lang.sysmlv2._ast.ASTSysMLModel;
 import de.monticore.lang.sysmlv2._cocos.SysMLv2CoCoChecker;
-import de.monticore.lang.sysmlv2._parser.SysMLv2Parser;
 import de.monticore.lang.sysmlv2._symboltable.ISysMLv2ArtifactScope;
 import de.monticore.lang.sysmlv2.cocos.RefinementTargetDefinitionExistsCoCo;
 import de.se_rwth.commons.logging.Finding;
@@ -23,11 +22,6 @@ import java.util.stream.Collectors;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class RefinementTargetDefinitionExistsCoCoTest {
-
-  private static final String MODEL_PATH = "src/test/resources/parser";
-
-  private SysMLv2Parser parser = SysMLv2Mill.parser();
-
   @BeforeAll
   public static void init() {
     Log.init();
@@ -46,8 +40,7 @@ public class RefinementTargetDefinitionExistsCoCoTest {
   public class RefinementTargetDefinitionExistsCoCoTests {
     @Test
     public void testValid() throws IOException {
-      String validModel =
-            "part def BasePart;"
+      String validModel = "part def BasePart;"
           + "part def Refining refines BasePart;";
 
       var ast = parse(validModel);
@@ -59,6 +52,29 @@ public class RefinementTargetDefinitionExistsCoCoTest {
     @Test
     public void testInvalid() throws IOException {
       String invalidModel = "part def Refining refines UndefinedBasePart;";
+
+      var ast = parse(invalidModel);
+      createSt(ast);
+      var errors = check(ast);
+      assertThat(errors).hasSize(1);
+      assertThat(errors.get(0).getMsg()).contains("0x10AA2");
+    }
+
+    @Test
+    public void testValidDependencyTarget() throws IOException {
+      String validModel = "part def BasePart;"
+          + "part def Refining2 { #refinement dependency to BasePart; }";
+
+      var ast = parse(validModel);
+      createSt(ast);
+      var errors = check(ast);
+      assertThat(errors).hasSize(0);
+    }
+
+    @Test
+    public void testInvalidDependencyTarget() throws IOException {
+      String invalidModel =
+          "part def Refining2 { #refinement dependency to UndefinedBasePart; }";
 
       var ast = parse(invalidModel);
       createSt(ast);


### PR DESCRIPTION
### Changelog
- #refinement dependency to Y; wird jetzt unterstützt.
- Cocos und tests sind entsprechend angepasst, bzw ergänzt