### PR TITLE
7.8.34: Make Packages First-class Citizens in Scope Delegation

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,4 +25,4 @@ assertj_version    = 3.21.0
 junit_version      = 5.8.2
 
 # Version of published artifacts
-version            = 7.8.33
+version            = 7.8.34

--- a/language/src/main/java/de/monticore/lang/sysmlv2/_symboltable/ISysMLv2Scope.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/_symboltable/ISysMLv2Scope.java
@@ -96,7 +96,6 @@ public interface ISysMLv2Scope extends ISysMLv2ScopeTOP {
     Predicate<TypeSymbol> predicate
   ) {
     final LinkedHashSet<TypeSymbol> result = new LinkedHashSet<>();
-
     if (
       checkIfContinueWithEnclosingScope(foundSymbols)
       && getEnclosingScope() != null
@@ -105,8 +104,7 @@ public interface ISysMLv2Scope extends ISysMLv2ScopeTOP {
       Set<String> potentialNames = calcQNamesForEnclosingScope(name);
 
       for (String potentialName : potentialNames) {
-        result.addAll(getEnclosingScope().resolveTypeMany(
-          foundSymbols,
+        result.addAll(getEnclosingScope().resolveTypeMany( foundSymbols,
           potentialName,
           modifier,
           predicate)
@@ -117,7 +115,12 @@ public interface ISysMLv2Scope extends ISysMLv2ScopeTOP {
     return new ArrayList<>(result);
   }
 
-
+  /**
+   * This method is essentially copied from artifact scopes. See explanation
+   * on continueTypeWithEnclosingScope(4): MontiCore's symbol resolution is
+   * Java-like out-of-the-box and needs to be extended for SysMLv2's usage
+   * of packages (namespaces) as proper modeling elements.
+   */
   default Set<String> calcQNamesForEnclosingScope(String name) {
     Set<String> potentialSymbolNames = new LinkedHashSet<>();
     potentialSymbolNames.add(name);
@@ -129,7 +132,7 @@ public interface ISysMLv2Scope extends ISysMLv2ScopeTOP {
       potentialSymbolNames.add(this.getSpanningSymbol().getName() + "." + name);
     }
 
-    //import Statements are not considered in local Scopes
+    // import statements are not yet considered
 
     return potentialSymbolNames;
   }

--- a/language/src/main/java/de/monticore/lang/sysmlv2/_symboltable/ISysMLv2Scope.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/_symboltable/ISysMLv2Scope.java
@@ -56,6 +56,27 @@ import java.util.function.Predicate;
 
 public interface ISysMLv2Scope extends ISysMLv2ScopeTOP {
 
+  /**
+   * In SysML, namespaces live inside SysML models (keyword "package") and
+   * there can be multiple namespaces in a single model. This is sometimes
+   * referred to as "first class support" of namespaces. In Java-like
+   * programming languages, the namespace of an artifact is handled implicitly
+   * through the file system path (in conjunction with a package declaration
+   * for easier inside-out-resolving). Blocks, methods, or classes are not
+   * considered full namespaces (resolving "bar" from within a class "Foo"
+   * does not yield the potential qualified name "Foo.bar" at the global scope).
+   * MontiCore's default resolve-mechanism is built to behave Java-like, i.e.,
+   * it assumes that namespaces exist only at the file level and only package
+   * declarations matter for the calculation of potential names. Therefore, the
+   * logic of looking for all potential qualified names is only executed when
+   * leaving the artifact scope and does not account for any scope names passed
+   * on the way up.
+   * This override changes this. It explicitly adds one new potential name to
+   * the list of potential names every time a package is passed while continuing
+   * with the enclosing scope. Assume we look for "bar", we pass "package Foo",
+   * then the list of potential names we are resolving for is now
+   * ["bar", "Foo.bar"].
+   */
   @Override
   default List<TypeSymbol> continueTypeWithEnclosingScope(
     boolean foundSymbols,

--- a/language/src/main/java/de/monticore/lang/sysmlv2/_symboltable/ISysMLv2Scope.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/_symboltable/ISysMLv2Scope.java
@@ -12,6 +12,7 @@ import de.monticore.lang.sysmlconstraints._ast.ASTRequirementUsage;
 import de.monticore.lang.sysmlconstraints._symboltable.RequirementSubjectSymbol;
 import de.monticore.lang.sysmlconstraints.symboltable.adapters.RequirementSubject2VariableSymbolAdapter;
 import de.monticore.lang.sysmlimportsandpackages._symboltable.SysMLMetaDataDefinitionSymbol;
+import de.monticore.lang.sysmlimportsandpackages._symboltable.SysMLPackageSymbol;
 import de.monticore.lang.sysmloccurrences.symboltable.adapters.ItemDef2TypeSymbolAdapter;
 import de.monticore.lang.sysmlparts._symboltable.AttributeUsageSymbol;
 import de.monticore.lang.sysmlparts._symboltable.PartUsageSymbol;
@@ -54,6 +55,52 @@ import java.util.Set;
 import java.util.function.Predicate;
 
 public interface ISysMLv2Scope extends ISysMLv2ScopeTOP {
+
+  @Override
+  default List<TypeSymbol> continueTypeWithEnclosingScope(
+    boolean foundSymbols,
+    String name,
+    AccessModifier modifier,
+    Predicate<TypeSymbol> predicate
+  ) {
+    final LinkedHashSet<TypeSymbol> result = new LinkedHashSet<>();
+
+    if (
+      checkIfContinueWithEnclosingScope(foundSymbols)
+      && getEnclosingScope() != null
+    ) {
+
+      Set<String> potentialNames = calcQNamesForEnclosingScope(name);
+
+      for (String potentialName : potentialNames) {
+        result.addAll(getEnclosingScope().resolveTypeMany(
+          foundSymbols,
+          potentialName,
+          modifier,
+          predicate)
+        );
+      }
+    }
+
+    return new ArrayList<>(result);
+  }
+
+
+  default Set<String> calcQNamesForEnclosingScope(String name) {
+    Set<String> potentialSymbolNames = new LinkedHashSet<>();
+    potentialSymbolNames.add(name);
+
+    if (
+      this.isPresentSpanningSymbol()
+      && this.getSpanningSymbol() instanceof SysMLPackageSymbol
+    ) {
+      potentialSymbolNames.add(this.getSpanningSymbol().getName() + "." + name);
+    }
+
+    //import Statements are not considered in local Scopes
+
+    return potentialSymbolNames;
+  }
 
   @Override
   default List<RequirementSymbol> resolveRequirementLocallyMany(

--- a/language/src/main/java/de/monticore/lang/sysmlv2/_symboltable/ISysMLv2Scope.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/_symboltable/ISysMLv2Scope.java
@@ -71,11 +71,22 @@ public interface ISysMLv2Scope extends ISysMLv2ScopeTOP {
    * logic of looking for all potential qualified names is only executed when
    * leaving the artifact scope and does not account for any scope names passed
    * on the way up.
+   * <br>
    * This override changes this. It explicitly adds one new potential name to
    * the list of potential names every time a package is passed while continuing
    * with the enclosing scope. Assume we look for "bar", we pass "package Foo",
    * then the list of potential names we are resolving for is now
    * ["bar", "Foo.bar"].
+   * <br>
+   * <b>Notice</b>: SysML comes with a large number of keywords
+   * (e.g., occurrence, item, attribute, part) that have no or very little
+   * meaning wrt. to symbol resolution. In MontiCore, we already established the
+   * basic set of symbols (aptly named "BasicSymbols"), namely Types, Variables,
+   * and Functions. To avoid re-implementing resolving functionality for all
+   * keywords, we use symbol adapters from SysML definitions to MontiCore types,
+   * SysML usages to MontiCore variables, and SysML constraints (including
+   * calc defs) to MontiCore functions. This method here handles resolving of
+   * MontiCore types, i.e., SysML definitions.
    */
   @Override
   default List<TypeSymbol> continueTypeWithEnclosingScope(


### PR DESCRIPTION
### Changelog
- **Problem**: 
  - Standard resolution keeps the searched name unchanged while ascending scopes, only composing fully qualified names at the artifact boundary (Java-like resolution).
  - SysMLv2 models can nest packages as model elements. These internal packages define effective namespaces that were previously ignored during upward delegation.
 
Example Model:
```
package Wrapper{
    package A{
        part def B;
    }
    part def C : A::B;
}
```
- **Solution**: 
  - Implemented package-aware symbol resolution where the resolver now recognizes when it leaves a package scope and qualifies the searched name with that package’s name (e.g., `Wrapper.A.B`). This ensures that the `GlobalScope` receives the necessary context for segment-wise resolution.