### PR TITLE
7.8.39 Corrected adaptedResolve for CC-Requirements in ISysMLScope

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,4 +25,4 @@ assertj_version    = 3.21.0
 junit_version      = 5.8.2
 
 # Version of published artifacts
-version            = 7.8.38
+version            = 7.8.39

--- a/language/src/main/java/de/monticore/lang/sysmlv2/_symboltable/ISysMLv2Scope.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/_symboltable/ISysMLv2Scope.java
@@ -270,16 +270,19 @@ public interface ISysMLv2Scope extends ISysMLv2ScopeTOP {
   }
 
   @Override
-  default List<RequirementSymbol> resolveRequirementLocallyMany(
+  default List<RequirementSymbol> resolveAdaptedRequirementLocallyMany(
       boolean foundSymbols,
-      String name, AccessModifier modifier,
+      String name,
+      AccessModifier modifier,
       Predicate<RequirementSymbol> predicate) {
     var adapted = new ArrayList<RequirementSymbol>();
-    var req = resolveRequirementUsageLocally(name);
+    var usages = resolveRequirementUsageLocallyMany(foundSymbols, name, modifier, x -> true);
 
-    if(req.isPresent()) {
-      var ccReq = new Requirement2RequirementCCAdapter(req.get());
-      adapted.add(ccReq);
+    for(var req : usages) {
+      var ccAdaptedReq = new Requirement2RequirementCCAdapter(req);
+      if(predicate.test(ccAdaptedReq)) {
+        adapted.add(ccAdaptedReq);
+      }
     }
 
     return adapted;


### PR DESCRIPTION
## Changed
* The Adapted CC-Requirements are correctly resolved via the "resolveAdapted" function, instead of overwriting the resolve directly 