### PR TITLE
ScalarValues-Importe werden im Symboltable unterstützt

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,4 +25,4 @@ assertj_version    = 3.21.0
 junit_version      = 5.8.2
 
 # Version of published artifacts
-version            = 7.8.38
+version            = 7.8.40

--- a/language/src/main/java/de/monticore/lang/sysmlv2/SysMLv2Mill.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/SysMLv2Mill.java
@@ -13,12 +13,14 @@ import de.monticore.symbols.basicsymbols._symboltable.VariableSymbol;
 import de.monticore.symbols.oosymbols.OOSymbolsMill;
 import de.monticore.symbols.oosymbols._symboltable.OOSymbolsScope;
 import de.monticore.symbols.oosymbols._symboltable.OOTypeSymbol;
+import de.monticore.lang.sysmlv2._symboltable.ISysMLv2Scope;
 import de.monticore.symboltable.modifiers.AccessModifier;
 import de.monticore.types.check.SymTypeExpressionFactory;
 import de.monticore.types.check.SymTypePrimitive;
 import de.monticore.types.check.SymTypeVariable;
 
 import java.util.Arrays;
+import java.util.List;
 
 import static de.monticore.symbols.basicsymbols.BasicSymbolsMillTOP.getMill;
 
@@ -31,6 +33,7 @@ public class SysMLv2Mill extends SysMLv2MillTOP {
   public static void prepareGlobalScope() {
     SysMLv2Mill.initializePrimitives();
     SysMLv2Mill.addStringType();
+    SysMLv2Mill.addScalarValueTypes();
     SysMLv2Mill.addCollectionTypes();
     SysMLv2Mill.addTsynVariables();
   }
@@ -61,6 +64,10 @@ public class SysMLv2Mill extends SysMLv2MillTOP {
     getMill()._addStringType();
   }
 
+  public static void addScalarValueTypes() {
+    getMill()._addScalarValueTypes();
+  }
+
   protected void _addStringType() {
     // ensures adding the type symbol only once
     if (SysMLv2Mill.globalScope().resolveType("String").isPresent()) {
@@ -73,6 +80,62 @@ public class SysMLv2Mill extends SysMLv2MillTOP {
         .build();
 
     SysMLv2Mill.globalScope().add(type);
+  }
+
+  protected void _addScalarValueTypes() {
+    if (SysMLv2Mill.globalScope().resolveSysMLPackage("ScalarValues").isPresent()) {
+      return;
+    }
+
+    var packageScope = SysMLv2Mill.scope();
+    packageScope.setName("ScalarValues");
+    packageScope.setEnclosingScope(SysMLv2Mill.globalScope());
+    var scalarValues = SysMLv2Mill.sysMLPackageSymbolBuilder()
+        .setName("ScalarValues")
+        .setFullName("ScalarValues")
+        .setPackageName("")
+        .setEnclosingScope(SysMLv2Mill.globalScope())
+        .setSpannedScope(packageScope)
+        .build();
+    packageScope.setSpanningSymbol(scalarValues);
+    SysMLv2Mill.globalScope().add(scalarValues);
+
+    var scalarValue = createScalarValueType(packageScope, "ScalarValue");
+    var bool = createScalarValueType(packageScope, "Boolean");
+    var numericalValue = createScalarValueType(packageScope, "NumericalValue");
+    var number = createScalarValueType(packageScope, "Number");
+    var complex = createScalarValueType(packageScope, "Complex");
+    var real = createScalarValueType(packageScope, "Real");
+    var rational = createScalarValueType(packageScope, "Rational");
+    var integer = createScalarValueType(packageScope, "Integer");
+    var natural = createScalarValueType(packageScope, "Natural");
+    var positive = createScalarValueType(packageScope, "Positive");
+
+    setScalarValueSuperTypes(bool, scalarValue);
+    setScalarValueSuperTypes(numericalValue, scalarValue);
+    setScalarValueSuperTypes(number, numericalValue);
+    setScalarValueSuperTypes(complex, number);
+    setScalarValueSuperTypes(real, complex);
+    setScalarValueSuperTypes(rational, real);
+    setScalarValueSuperTypes(integer, rational);
+    setScalarValueSuperTypes(natural, integer);
+    setScalarValueSuperTypes(positive, natural);
+  }
+
+  protected OOTypeSymbol createScalarValueType(ISysMLv2Scope packageScope, String name) {
+    var type = OOSymbolsMill.oOTypeSymbolBuilder()
+        .setName(name)
+        .setFullName("ScalarValues." + name)
+        .setPackageName("ScalarValues")
+        .setEnclosingScope(packageScope)
+        .setSpannedScope(scope())
+        .build();
+    packageScope.add(type);
+    return type;
+  }
+
+  protected void setScalarValueSuperTypes(OOTypeSymbol type, OOTypeSymbol superType) {
+    type.setSuperTypesList(List.of(SymTypeExpressionFactory.createTypeObject(superType)));
   }
 
   protected OOTypeSymbol buildOptionalType() {

--- a/language/src/test/java/symboltable/SerializationTest.java
+++ b/language/src/test/java/symboltable/SerializationTest.java
@@ -135,7 +135,7 @@ public class SerializationTest {
       String usageSymbol)
   {
     ASTSysMLModel ast = sysmlTool.parse(modelReferencePath);
-    sysmlTool.createSymbolTable(ast);
+    ISysMLv2ArtifactScope artifactScope = sysmlTool.createSymbolTable(ast);
 
     var symbolPath = new MCPath();
     // MCPath entries correspond to the directories that contain symboltables
@@ -149,8 +149,9 @@ public class SerializationTest {
     // check if an additional ArtifactScope was found during completion (Specialization completion uses inter-model resolution)
     Assertions.assertThat(gs.getSubScopes()).size().isGreaterThan(1);
 
-    // check inter-model resolution of fqn from usage package scope.
-    ISysMLv2Scope packageScope = gs.getSubScopes().get(0).getSubScopes().get(0);
+    // check inter-model resolution of fqn from the package scope of the reference artifact.
+    Assertions.assertThat(artifactScope.getSubScopes()).isNotEmpty();
+    ISysMLv2Scope packageScope = artifactScope.getSubScopes().get(0);
     Optional<SysMLTypeSymbol> resolved = packageScope.resolveSysMLType(fqnSymbol);
     assertThat(resolved).isPresent();
 

--- a/language/src/test/java/symboltable/SymbolTableCompletionTest.java
+++ b/language/src/test/java/symboltable/SymbolTableCompletionTest.java
@@ -2,6 +2,7 @@ package symboltable;
 
 import de.monticore.expressions.commonexpressions._ast.ASTCallExpression;
 import de.monticore.lang.sysmlconstraints._ast.ASTConstraintUsage;
+import de.monticore.lang.sysmlparts._ast.ASTAttributeUsage;
 import de.monticore.lang.sysmlparts._ast.ASTPartDef;
 import de.monticore.lang.sysmlv2.SysMLv2Mill;
 import de.monticore.lang.sysmlv2.SysMLv2Tool;
@@ -248,6 +249,33 @@ public class SymbolTableCompletionTest {
     var type = deriver.deriveType(atTime);
     assertThat(type.isPresentResult());
     assertThat(type.getResult().printFullName()).isEqualTo("UntimedStream.UntimedStream<int>");
+  }
+
+  @Test
+  public void testImportedScalarValueCompletesAttributeTypes() throws IOException {
+    var model = ""
+        + "private import ScalarValues::Boolean;\n"
+        + "private import ScalarValues::Natural;\n"
+        + "attribute flag: Boolean;\n"
+        + "attribute size: Natural;";
+
+    Optional<ASTSysMLModel> optAst = parser.parse_String(model);
+    assertThat(optAst).isPresent();
+
+    var ast = optAst.get();
+
+    tool.createSymbolTable(ast);
+    tool.completeSymbolTable(ast);
+    tool.finalizeSymbolTable(ast);
+    assertThat(Log.getFindings()).isEmpty();
+
+    var flag = (ASTAttributeUsage) ast.getSysMLElement(2);
+    var size = (ASTAttributeUsage) ast.getSysMLElement(3);
+
+    assertThat(flag.getSymbol().getTypesList()).hasSize(1);
+    assertThat(flag.getSymbol().getTypesList().get(0).printFullName()).isEqualTo("ScalarValues.Boolean");
+    assertThat(size.getSymbol().getTypesList()).hasSize(1);
+    assertThat(size.getSymbol().getTypesList().get(0).printFullName()).isEqualTo("ScalarValues.Natural");
   }
 
   /**


### PR DESCRIPTION
Es wurde die Symbolauflösung für ScalarValues angepasst. ScalarValues ist keine sysml-, sondern eine KerML-Datei. Da die aktuelle Verarbeitung diese Bibliothek noch nicht direkt lädt, wurde ScalarValues im Symboltable synthetisch ergänzt.

Dadurch können Importe wie `import ScalarValues::Boolean` oder `import ScalarValues::Natural ` korrekt aufgelöst werden. 