### PR TITLE
treat calc def as function symbol

### DIFF
--- a/language/src/main/java/de/monticore/lang/sysmlactions/_symboltable/CalcDefSymbol.java
+++ b/language/src/main/java/de/monticore/lang/sysmlactions/_symboltable/CalcDefSymbol.java
@@ -1,0 +1,19 @@
+package de.monticore.lang.sysmlactions._symboltable;
+
+import de.monticore.types.check.SymTypeExpression;
+
+public class CalcDefSymbol extends CalcDefSymbolTOP {
+  protected SymTypeExpression returnType;
+
+  public CalcDefSymbol(String name) {
+    super(name);
+  }
+
+  public SymTypeExpression getReturnType() {
+    return returnType;
+  }
+
+  public void setReturnType(SymTypeExpression returnType) {
+    this.returnType = returnType;
+  }
+}

--- a/language/src/main/java/de/monticore/lang/sysmlparts/symboltable/adapters/CalcDef2FunctionSymbolAdapter.java
+++ b/language/src/main/java/de/monticore/lang/sysmlparts/symboltable/adapters/CalcDef2FunctionSymbolAdapter.java
@@ -1,0 +1,60 @@
+package de.monticore.lang.sysmlparts.symboltable.adapters;
+
+import com.google.common.base.Preconditions;
+import de.monticore.lang.sysmlactions._symboltable.CalcDefSymbol;
+import de.monticore.symbols.basicsymbols.BasicSymbolsMill;
+import de.monticore.symbols.basicsymbols._symboltable.FunctionSymbol;
+import de.monticore.symbols.basicsymbols._symboltable.IBasicSymbolsScope;
+import de.se_rwth.commons.SourcePosition;
+
+/**
+ * Adapts a SysML {@link CalcDefSymbol} to a MontiCore {@link FunctionSymbol}.
+ *
+ * MontiCore's expression type checker resolves function calls against
+ * {@link FunctionSymbol}s from BasicSymbols. SysML calc def, however, are represented by
+ * {@link CalcDefSymbol}s. This adapter exposes a calc def as a function symbol so that
+ * expressions such as {@code f.bar()} can be resolved and type-checked using the existing
+ * function-call infrastructure.
+ */
+public class CalcDef2FunctionSymbolAdapter extends FunctionSymbol {
+  protected CalcDefSymbol adaptee;
+
+  public CalcDef2FunctionSymbolAdapter(CalcDefSymbol adaptee) {
+    super(Preconditions.checkNotNull(adaptee.getName()));
+    this.adaptee = adaptee;
+
+    setAccessModifier(adaptee.getAccessModifier());
+
+    IBasicSymbolsScope spannedScope = BasicSymbolsMill.scope();
+    spannedScope.setName(adaptee.getName());
+    spannedScope.setShadowing(true);
+    spannedScope.setEnclosingScope(adaptee.getEnclosingScope());
+    setSpannedScope(spannedScope);
+
+    setType(adaptee.getReturnType());
+  }
+
+  protected CalcDefSymbol getAdaptee() {
+    return adaptee;
+  }
+
+  @Override
+  public String getName() {
+    return adaptee.getName();
+  }
+
+  @Override
+  public String getFullName() {
+    return adaptee.getFullName();
+  }
+
+  @Override
+  public IBasicSymbolsScope getEnclosingScope() {
+    return adaptee.getEnclosingScope();
+  }
+
+  @Override
+  public SourcePosition getSourcePosition() {
+    return adaptee.getSourcePosition();
+  }
+}

--- a/language/src/main/java/de/monticore/lang/sysmlv2/_symboltable/ISysMLv2Scope.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/_symboltable/ISysMLv2Scope.java
@@ -22,6 +22,7 @@ import de.monticore.lang.sysmlparts.symboltable.adapters.AnonymousUsage2Variable
 import de.monticore.lang.sysmlparts.symboltable.adapters.AttributeDef2TypeSymbolAdapter;
 import de.monticore.lang.sysmlparts.symboltable.adapters.AttributeUsage2TypeSymbolAdapter;
 import de.monticore.lang.sysmlparts.symboltable.adapters.AttributeUsage2VariableSymbolAdapter;
+import de.monticore.lang.sysmlparts.symboltable.adapters.CalcDef2FunctionSymbolAdapter;
 import de.monticore.lang.sysmlparts.symboltable.adapters.CalcUsage2FunctionSymbolAdapter;
 import de.monticore.lang.sysmlparts.symboltable.adapters.EnumDef2TypeSymbolAdapter;
 import de.monticore.lang.sysmlparts.symboltable.adapters.PartDef2TypeSymbolAdapter;
@@ -49,7 +50,6 @@ import de.monticore.symboltable.ImportStatement;
 import de.monticore.symboltable.modifiers.AccessModifier;
 import de.monticore.types.check.SymTypeExpression;
 import de.monticore.types.check.SymTypeExpressionFactory;
-import de.se_rwth.commons.logging.Log;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -689,6 +689,11 @@ public interface ISysMLv2Scope extends ISysMLv2ScopeTOP {
     var calcUsage = resolveCalcUsageLocally(name);
     if (calcUsage.isPresent()) {
       adapted.add(new CalcUsage2FunctionSymbolAdapter(calcUsage.get()));
+    }
+
+    var calcDef = resolveCalcDefLocally(name);
+    if (calcDef.isPresent()) {
+      adapted.add(new CalcDef2FunctionSymbolAdapter(calcDef.get()));
     }
     return adapted;
   }

--- a/language/src/main/java/de/monticore/lang/sysmlv2/cocos/MaxOneDirectReturnInCalcDefCoCo.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/cocos/MaxOneDirectReturnInCalcDefCoCo.java
@@ -1,7 +1,7 @@
 package de.monticore.lang.sysmlv2.cocos;
 
-import de.monticore.lang.sysmlactions._ast.ASTCalcUsage;
-import de.monticore.lang.sysmlactions._cocos.SysMLActionsASTCalcUsageCoCo;
+import de.monticore.lang.sysmlactions._ast.ASTCalcDef;
+import de.monticore.lang.sysmlactions._cocos.SysMLActionsASTCalcDefCoCo;
 import de.monticore.lang.sysmlbasis._ast.ASTAnonymousUsage;
 import de.monticore.lang.sysmlbasis._visitor.SysMLBasisVisitor2;
 import de.monticore.lang.sysmlparts._ast.ASTAttributeUsage;
@@ -10,12 +10,12 @@ import de.monticore.lang.sysmlv2.SysMLv2Mill;
 import de.se_rwth.commons.logging.Log;
 
 /**
- * Checks that a calc usage contains at most one direct return usage.
+ * Checks that a calc def contains at most one direct return.
  * Nested return usages are ignored.
  */
-public class OneDirectReturnInCalcUsageCoCo implements SysMLActionsASTCalcUsageCoCo {
+public class MaxOneDirectReturnInCalcDefCoCo implements SysMLActionsASTCalcDefCoCo {
   @Override
-  public void check(ASTCalcUsage node) {
+  public void check(ASTCalcDef node) {
     final int[] returnCount = {0};
     var traverser = SysMLv2Mill.inheritanceTraverser();
 
@@ -40,7 +40,7 @@ public class OneDirectReturnInCalcUsageCoCo implements SysMLActionsASTCalcUsageC
     node.accept(traverser);
 
     if (returnCount[0] > 1) {
-      Log.error("0x10384 Calc usage must contain at most one direct return usage.", node.get_SourcePositionStart());
+      Log.error("0x10385 Calc def must contain at most one direct return.", node.get_SourcePositionStart());
     }
   }
 }

--- a/language/src/main/java/de/monticore/lang/sysmlv2/cocos/MaxOneDirectReturnInCalcUsageCoCo.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/cocos/MaxOneDirectReturnInCalcUsageCoCo.java
@@ -1,0 +1,46 @@
+package de.monticore.lang.sysmlv2.cocos;
+
+import de.monticore.lang.sysmlactions._ast.ASTCalcUsage;
+import de.monticore.lang.sysmlactions._cocos.SysMLActionsASTCalcUsageCoCo;
+import de.monticore.lang.sysmlbasis._ast.ASTAnonymousUsage;
+import de.monticore.lang.sysmlbasis._visitor.SysMLBasisVisitor2;
+import de.monticore.lang.sysmlparts._ast.ASTAttributeUsage;
+import de.monticore.lang.sysmlparts._visitor.SysMLPartsVisitor2;
+import de.monticore.lang.sysmlv2.SysMLv2Mill;
+import de.se_rwth.commons.logging.Log;
+
+/**
+ * Checks that a calc usage contains at most one direct return usage.
+ * Nested return usages are ignored.
+ */
+public class MaxOneDirectReturnInCalcUsageCoCo implements SysMLActionsASTCalcUsageCoCo {
+  @Override
+  public void check(ASTCalcUsage node) {
+    final int[] returnCount = {0};
+    var traverser = SysMLv2Mill.inheritanceTraverser();
+
+    traverser.add4SysMLBasis(new SysMLBasisVisitor2() {
+      @Override
+      public void visit(ASTAnonymousUsage retNode) {
+        if (retNode.getModifier().isReturn() && retNode.getEnclosingScope() == node.getSpannedScope()) {
+          returnCount[0]++;
+        }
+      }
+    });
+
+    traverser.add4SysMLParts(new SysMLPartsVisitor2() {
+      @Override
+      public void visit(ASTAttributeUsage retNode) {
+        if (retNode.getModifier().isReturn() && retNode.getEnclosingScope() == node.getSpannedScope()) {
+          returnCount[0]++;
+        }
+      }
+    });
+
+    node.accept(traverser);
+
+    if (returnCount[0] > 1) {
+      Log.error("0x10384 Calc usage must contain at most one direct return usage.", node.get_SourcePositionStart());
+    }
+  }
+}

--- a/language/src/main/java/de/monticore/lang/sysmlv2/symboltable/completers/TypesCompleter.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/symboltable/completers/TypesCompleter.java
@@ -44,23 +44,23 @@ public class TypesCompleter implements SysMLBasisVisitor2, SysMLPartsVisitor2,
   private List<SymTypeExpression> getTypeCompletion(List<ASTSpecialization> specializationList, boolean conjugated) {
     List<SymTypeExpression> typeExpressions = new ArrayList<>();
 
-    for (var specialization : specializationList) {
-      if (specialization instanceof ASTSysMLTyping && ((ASTSysMLTyping) specialization).isConjugated() == conjugated) {
+    for(var specialization : specializationList) {
+      if(specialization instanceof ASTSysMLTyping && ((ASTSysMLTyping) specialization).isConjugated() == conjugated) {
         var astTyping = (ASTSysMLTyping) specialization;
 
-        for (var mcType : astTyping.getSuperTypesList()) {
+        for(var mcType : astTyping.getSuperTypesList()) {
           SymTypeExpression res = null;
-          if (mcType instanceof ASTMCTupleType) {
+          if(mcType instanceof ASTMCTupleType) {
             var tupleType = (ASTMCTupleType) mcType;
             List<SymTypeExpression> componentTypes = new ArrayList<>();
-            for (var componentMcType : tupleType.getMCTypeList()) {
+            for(var componentMcType : tupleType.getMCTypeList()) {
               componentTypes.add(SymTypeExpressionFactory.createTypeExpression(
                   componentMcType.printType(),
                   (IBasicSymbolsScope) componentMcType.getEnclosingScope()));
             }
             res = SymTypeExpressionFactory.createTuple(componentTypes);
           }
-          else if (mcType instanceof ASTMCGenericType) {
+          else if(mcType instanceof ASTMCGenericType) {
             // We still have to print when the type is generic because the defining symbol does not give info about the
             // instantiation with type arguments
             res = SymTypeExpressionFactory.createTypeExpression(
@@ -75,15 +75,15 @@ public class TypesCompleter implements SysMLBasisVisitor2, SysMLPartsVisitor2,
               res = SymTypeExpressionFactory.createTypeExpression((TypeSymbol) mcType.getDefiningSymbol().get());
             }
           }
-          else if (mcType.getDefiningSymbol().isEmpty()) {
+          else if(mcType.getDefiningSymbol().isEmpty()) {
             Log.warn("Defining symbol for " + mcType.printType() + " was not set.");
           }
           else if (!(mcType.getDefiningSymbol().get() instanceof TypeSymbol)) {
             Log.warn("Defining symbol for " + mcType.printType() + " is not a TypeSymbol");
           }
 
-          if (res != null) {
-            if (astTyping.isPresentCardinality()) {
+          if(res != null) {
+            if(astTyping.isPresentCardinality()) {
               res = SymTypeExpressionFactory.createTypeArray(res.getTypeInfo(),1, res);
             }
             typeExpressions.add(res);
@@ -98,7 +98,7 @@ public class TypesCompleter implements SysMLBasisVisitor2, SysMLPartsVisitor2,
   public void visit(ASTSysMLParameter node) {
     List<SymTypeExpression> types = getTypeCompletion(node.getSpecializationList(), false);
 
-    if (node.isPresentSymbol() && !types.isEmpty()) {
+    if(node.isPresentSymbol() && !types.isEmpty()) {
       node.getSymbol().setType(types.get(0));
     }
   }
@@ -121,7 +121,7 @@ public class TypesCompleter implements SysMLBasisVisitor2, SysMLPartsVisitor2,
    */
   @Override
   public void visit(ASTPortUsage node) {
-    if (node.isPresentSymbol()) {
+    if(node.isPresentSymbol()) {
       PortUsageSymbol symbol = node.getSymbol();
 
       List<SymTypeExpression> types = getTypeCompletion(node.getSpecializationList(), false);
@@ -137,7 +137,7 @@ public class TypesCompleter implements SysMLBasisVisitor2, SysMLPartsVisitor2,
    */
   @Override
   public void visit(ASTAttributeUsage node) {
-    if (node.isPresentSymbol()) {
+    if(node.isPresentSymbol()) {
       AttributeUsageSymbol symbol = node.getSymbol();
       // type
       List<SymTypeExpression> types = getTypeCompletion(node.getSpecializationList(), false);

--- a/language/src/main/java/de/monticore/lang/sysmlv2/symboltable/completers/TypesCompleter.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/symboltable/completers/TypesCompleter.java
@@ -30,26 +30,22 @@ import de.monticore.types.check.SymTypeExpressionFactory;
 import de.monticore.types.mccollectiontypes._ast.ASTMCGenericType;
 import de.monticore.types.mcstructuraltypes._ast.ASTMCTupleType;
 import de.se_rwth.commons.logging.Log;
-
 import java.util.ArrayList;
 import java.util.List;
 
 public class TypesCompleter implements SysMLBasisVisitor2, SysMLPartsVisitor2,
-    SysMLConstraintsVisitor2, SysMLActionsVisitor2 {
+    SysMLConstraintsVisitor2, SysMLActionsVisitor2
+{
 
   /**
-   * Returns type completion for Usages. Bases on types completed in the
-   * SpecializationCompleter. We solely store the qualified name as
-   * SymTypeExpression using the defining symbol, outside of generic types
-   * (require type printing)
+   * Returns type completion for Usages. Bases on types completed in the SpecializationCompleter. We solely store the
+   * qualified name as SymTypeExpression using the defining symbol, outside of generic types (require type printing)
    */
-  private List<SymTypeExpression> getTypeCompletion(
-      List<ASTSpecialization> specializationList, boolean conjugated) {
+  private List<SymTypeExpression> getTypeCompletion(List<ASTSpecialization> specializationList, boolean conjugated) {
     List<SymTypeExpression> typeExpressions = new ArrayList<>();
 
     for (var specialization : specializationList) {
-      if (specialization instanceof ASTSysMLTyping
-          && ((ASTSysMLTyping) specialization).isConjugated() == conjugated) {
+      if (specialization instanceof ASTSysMLTyping && ((ASTSysMLTyping) specialization).isConjugated() == conjugated) {
         var astTyping = (ASTSysMLTyping) specialization;
 
         for (var mcType : astTyping.getSuperTypesList()) {
@@ -71,31 +67,24 @@ public class TypesCompleter implements SysMLBasisVisitor2, SysMLPartsVisitor2,
                 mcType.printType(),
                 (IBasicSymbolsScope) mcType.getEnclosingScope());
           }
-          else if (mcType.getDefiningSymbol().isPresent()
-              && mcType.getDefiningSymbol().get() instanceof TypeSymbol) {
+          else if (mcType.getDefiningSymbol().isPresent() && mcType.getDefiningSymbol().get() instanceof TypeSymbol) {
             // hacky setup such that nat remains a primitive
             if (mcType.getDefiningSymbol().get().getName().equals("nat")) {
-              res = SymTypeExpressionFactory.createPrimitive(
-                  (TypeSymbol) mcType.getDefiningSymbol().get());
-            }
-            else {
-              res = SymTypeExpressionFactory.createTypeExpression(
-                  (TypeSymbol) mcType.getDefiningSymbol().get());
+              res = SymTypeExpressionFactory.createPrimitive((TypeSymbol) mcType.getDefiningSymbol().get());
+            } else {
+              res = SymTypeExpressionFactory.createTypeExpression((TypeSymbol) mcType.getDefiningSymbol().get());
             }
           }
           else if (mcType.getDefiningSymbol().isEmpty()) {
-            Log.warn(
-                "Defining symbol for " + mcType.printType() + " was not set.");
+            Log.warn("Defining symbol for " + mcType.printType() + " was not set.");
           }
           else if (!(mcType.getDefiningSymbol().get() instanceof TypeSymbol)) {
-            Log.warn("Defining symbol for " + mcType.printType()
-                + " is not a TypeSymbol");
+            Log.warn("Defining symbol for " + mcType.printType() + " is not a TypeSymbol");
           }
 
           if (res != null) {
             if (astTyping.isPresentCardinality()) {
-              res = SymTypeExpressionFactory.createTypeArray(res.getTypeInfo(),
-                  1, res);
+              res = SymTypeExpressionFactory.createTypeArray(res.getTypeInfo(),1, res);
             }
             typeExpressions.add(res);
           }
@@ -107,8 +96,7 @@ public class TypesCompleter implements SysMLBasisVisitor2, SysMLPartsVisitor2,
 
   @Override
   public void visit(ASTSysMLParameter node) {
-    List<SymTypeExpression> types = getTypeCompletion(
-        node.getSpecializationList(), false);
+    List<SymTypeExpression> types = getTypeCompletion(node.getSpecializationList(), false);
 
     if (node.isPresentSymbol() && !types.isEmpty()) {
       node.getSymbol().setType(types.get(0));
@@ -116,14 +104,12 @@ public class TypesCompleter implements SysMLBasisVisitor2, SysMLPartsVisitor2,
   }
 
   /**
-   * Completes the usage symbol with corresponding types used by further
-   * model-processing tools. Type is stored as a SymTypeExpression and
-   * requires a backing Type symbol set by a SpecializationCompleter
+   * Completes the usage symbol with corresponding types used by further model-processing tools. Type is stored as a
+   * SymTypeExpression and requires a backing Type symbol set by a SpecializationCompleter
    */
   @Override
   public void visit(ASTPartUsage node) {
-    List<SymTypeExpression> types = getTypeCompletion(
-        node.getSpecializationList(), false);
+    List<SymTypeExpression> types = getTypeCompletion(node.getSpecializationList(), false);
 
     if (node.isPresentSymbol()) {
       node.getSymbol().setTypesList(types);
@@ -138,10 +124,8 @@ public class TypesCompleter implements SysMLBasisVisitor2, SysMLPartsVisitor2,
     if (node.isPresentSymbol()) {
       PortUsageSymbol symbol = node.getSymbol();
 
-      List<SymTypeExpression> types = getTypeCompletion(
-          node.getSpecializationList(), false);
-      List<SymTypeExpression> conjugatedTypes = getTypeCompletion(
-          node.getSpecializationList(), true);
+      List<SymTypeExpression> types = getTypeCompletion(node.getSpecializationList(), false);
+      List<SymTypeExpression> conjugatedTypes = getTypeCompletion(node.getSpecializationList(), true);
 
       symbol.setTypesList(types);
       symbol.setConjugatedTypesList(conjugatedTypes);
@@ -156,8 +140,7 @@ public class TypesCompleter implements SysMLBasisVisitor2, SysMLPartsVisitor2,
     if (node.isPresentSymbol()) {
       AttributeUsageSymbol symbol = node.getSymbol();
       // type
-      List<SymTypeExpression> types = getTypeCompletion(
-          node.getSpecializationList(), false);
+      List<SymTypeExpression> types = getTypeCompletion(node.getSpecializationList(), false);
 
       symbol.setAccessModifier(BasicAccessModifier.ALL_INCLUSION);
 

--- a/language/src/main/java/de/monticore/lang/sysmlv2/symboltable/completers/TypesCompleter.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/symboltable/completers/TypesCompleter.java
@@ -1,6 +1,7 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.lang.sysmlv2.symboltable.completers;
 
+import de.monticore.lang.sysmlactions._ast.ASTCalcDef;
 import de.monticore.lang.sysmlactions._ast.ASTCalcUsage;
 import de.monticore.lang.sysmlactions._visitor.SysMLActionsVisitor2;
 import de.monticore.lang.sysmlbasis._ast.ASTAnonymousReference;
@@ -34,57 +35,67 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class TypesCompleter implements SysMLBasisVisitor2, SysMLPartsVisitor2,
-    SysMLConstraintsVisitor2, SysMLActionsVisitor2
-{
+    SysMLConstraintsVisitor2, SysMLActionsVisitor2 {
 
   /**
-   * Returns type completion for Usages. Bases on types completed in the SpecializationCompleter. We solely store the
-   * qualified name as SymTypeExpression using the defining symbol, outside of generic types (require type printing)
+   * Returns type completion for Usages. Bases on types completed in the
+   * SpecializationCompleter. We solely store the qualified name as
+   * SymTypeExpression using the defining symbol, outside of generic types
+   * (require type printing)
    */
-  private List<SymTypeExpression> getTypeCompletion(List<ASTSpecialization> specializationList, boolean conjugated) {
+  private List<SymTypeExpression> getTypeCompletion(
+      List<ASTSpecialization> specializationList, boolean conjugated) {
     List<SymTypeExpression> typeExpressions = new ArrayList<>();
 
-    for(var specialization: specializationList) {
-      if(specialization instanceof ASTSysMLTyping && ((ASTSysMLTyping) specialization).isConjugated() == conjugated) {
+    for (var specialization : specializationList) {
+      if (specialization instanceof ASTSysMLTyping
+          && ((ASTSysMLTyping) specialization).isConjugated() == conjugated) {
         var astTyping = (ASTSysMLTyping) specialization;
 
-        for(var mcType: astTyping.getSuperTypesList()) {
+        for (var mcType : astTyping.getSuperTypesList()) {
           SymTypeExpression res = null;
-          if(mcType instanceof ASTMCTupleType) {
+          if (mcType instanceof ASTMCTupleType) {
             var tupleType = (ASTMCTupleType) mcType;
             List<SymTypeExpression> componentTypes = new ArrayList<>();
-            for(var componentMcType : tupleType.getMCTypeList()) {
+            for (var componentMcType : tupleType.getMCTypeList()) {
               componentTypes.add(SymTypeExpressionFactory.createTypeExpression(
                   componentMcType.printType(),
                   (IBasicSymbolsScope) componentMcType.getEnclosingScope()));
             }
             res = SymTypeExpressionFactory.createTuple(componentTypes);
           }
-          else if(mcType instanceof ASTMCGenericType) {
+          else if (mcType instanceof ASTMCGenericType) {
             // We still have to print when the type is generic because the defining symbol does not give info about the
             // instantiation with type arguments
             res = SymTypeExpressionFactory.createTypeExpression(
                 mcType.printType(),
                 (IBasicSymbolsScope) mcType.getEnclosingScope());
           }
-          else if(mcType.getDefiningSymbol().isPresent() && mcType.getDefiningSymbol().get() instanceof TypeSymbol) {
+          else if (mcType.getDefiningSymbol().isPresent()
+              && mcType.getDefiningSymbol().get() instanceof TypeSymbol) {
             // hacky setup such that nat remains a primitive
             if (mcType.getDefiningSymbol().get().getName().equals("nat")) {
-              res = SymTypeExpressionFactory.createPrimitive((TypeSymbol) mcType.getDefiningSymbol().get());
-            } else {
-              res = SymTypeExpressionFactory.createTypeExpression((TypeSymbol) mcType.getDefiningSymbol().get());
+              res = SymTypeExpressionFactory.createPrimitive(
+                  (TypeSymbol) mcType.getDefiningSymbol().get());
+            }
+            else {
+              res = SymTypeExpressionFactory.createTypeExpression(
+                  (TypeSymbol) mcType.getDefiningSymbol().get());
             }
           }
-          else if(mcType.getDefiningSymbol().isEmpty()) {
-            Log.warn("Defining symbol for " + mcType.printType() + " was not set.");
+          else if (mcType.getDefiningSymbol().isEmpty()) {
+            Log.warn(
+                "Defining symbol for " + mcType.printType() + " was not set.");
           }
-          else if(!(mcType.getDefiningSymbol().get() instanceof TypeSymbol)) {
-            Log.warn("Defining symbol for " + mcType.printType() + " is not a TypeSymbol");
+          else if (!(mcType.getDefiningSymbol().get() instanceof TypeSymbol)) {
+            Log.warn("Defining symbol for " + mcType.printType()
+                + " is not a TypeSymbol");
           }
 
-          if(res != null) {
-            if(astTyping.isPresentCardinality()) {
-              res = SymTypeExpressionFactory.createTypeArray(res.getTypeInfo(), 1, res);
+          if (res != null) {
+            if (astTyping.isPresentCardinality()) {
+              res = SymTypeExpressionFactory.createTypeArray(res.getTypeInfo(),
+                  1, res);
             }
             typeExpressions.add(res);
           }
@@ -96,22 +107,25 @@ public class TypesCompleter implements SysMLBasisVisitor2, SysMLPartsVisitor2,
 
   @Override
   public void visit(ASTSysMLParameter node) {
-    List<SymTypeExpression> types = getTypeCompletion(node.getSpecializationList(), false);
+    List<SymTypeExpression> types = getTypeCompletion(
+        node.getSpecializationList(), false);
 
-    if(node.isPresentSymbol() && !types.isEmpty()) {
+    if (node.isPresentSymbol() && !types.isEmpty()) {
       node.getSymbol().setType(types.get(0));
     }
   }
 
   /**
-   * Completes the usage symbol with corresponding types used by further model-processing tools. Type is stored as a
-   * SymTypeExpression and requires a backing Type symbol set by a SpecializationCompleter
+   * Completes the usage symbol with corresponding types used by further
+   * model-processing tools. Type is stored as a SymTypeExpression and
+   * requires a backing Type symbol set by a SpecializationCompleter
    */
   @Override
   public void visit(ASTPartUsage node) {
-    List<SymTypeExpression> types = getTypeCompletion(node.getSpecializationList(), false);
+    List<SymTypeExpression> types = getTypeCompletion(
+        node.getSpecializationList(), false);
 
-    if(node.isPresentSymbol()) {
+    if (node.isPresentSymbol()) {
       node.getSymbol().setTypesList(types);
     }
   }
@@ -121,11 +135,13 @@ public class TypesCompleter implements SysMLBasisVisitor2, SysMLPartsVisitor2,
    */
   @Override
   public void visit(ASTPortUsage node) {
-    if(node.isPresentSymbol()) {
+    if (node.isPresentSymbol()) {
       PortUsageSymbol symbol = node.getSymbol();
 
-      List<SymTypeExpression> types = getTypeCompletion(node.getSpecializationList(), false);
-      List<SymTypeExpression> conjugatedTypes = getTypeCompletion(node.getSpecializationList(), true);
+      List<SymTypeExpression> types = getTypeCompletion(
+          node.getSpecializationList(), false);
+      List<SymTypeExpression> conjugatedTypes = getTypeCompletion(
+          node.getSpecializationList(), true);
 
       symbol.setTypesList(types);
       symbol.setConjugatedTypesList(conjugatedTypes);
@@ -137,10 +153,11 @@ public class TypesCompleter implements SysMLBasisVisitor2, SysMLPartsVisitor2,
    */
   @Override
   public void visit(ASTAttributeUsage node) {
-    if(node.isPresentSymbol()) {
+    if (node.isPresentSymbol()) {
       AttributeUsageSymbol symbol = node.getSymbol();
       // type
-      List<SymTypeExpression> types = getTypeCompletion(node.getSpecializationList(), false);
+      List<SymTypeExpression> types = getTypeCompletion(
+          node.getSpecializationList(), false);
 
       symbol.setAccessModifier(BasicAccessModifier.ALL_INCLUSION);
 
@@ -150,6 +167,39 @@ public class TypesCompleter implements SysMLBasisVisitor2, SysMLPartsVisitor2,
 
   @Override
   public void endVisit(ASTCalcUsage node) {
+    if (node.isPresentSymbol()) {
+      // Use a one-element array because Java does not allow reassigning local variables
+      // from inside anonymous visitor classes
+      final SymTypeExpression[] returnType = new SymTypeExpression[1];
+      returnType[0] = SymTypeExpressionFactory.createTopType();
+
+      var traverser = SysMLv2Mill.inheritanceTraverser();
+      traverser.add4SysMLBasis(new SysMLBasisVisitor2() {
+        @Override
+        public void visit(ASTAnonymousUsage retNode) {
+          if (retNode.getModifier().isReturn() && retNode.getEnclosingScope() == node.getSpannedScope()) {
+            List<SymTypeExpression> types = getTypeCompletion(retNode.getSpecializationList(), false);
+            returnType[0] = types.isEmpty() ? SymTypeExpressionFactory.createObscureType() : types.get(0);
+          }
+        }
+      });
+
+      traverser.add4SysMLParts(new SysMLPartsVisitor2() {
+        @Override
+        public void visit(ASTAttributeUsage retNode) {
+          if (retNode.getModifier().isReturn() && retNode.getEnclosingScope() == node.getSpannedScope()) {
+            List<SymTypeExpression> types = getTypeCompletion(retNode.getSpecializationList(), false);
+            returnType[0] = types.isEmpty() ? SymTypeExpressionFactory.createObscureType() : types.get(0);
+          }
+        }
+      });
+      node.accept(traverser);
+      node.getSymbol().setReturnType(returnType[0]);
+    }
+  }
+
+  @Override
+  public void endVisit(ASTCalcDef node) {
     if (node.isPresentSymbol()) {
       // Use a one-element array because Java does not allow reassigning local variables
       // from inside anonymous visitor classes

--- a/language/src/main/java/de/monticore/lang/sysmlv2/symboltable/completers/TypesCompleter.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/symboltable/completers/TypesCompleter.java
@@ -44,11 +44,11 @@ public class TypesCompleter implements SysMLBasisVisitor2, SysMLPartsVisitor2,
   private List<SymTypeExpression> getTypeCompletion(List<ASTSpecialization> specializationList, boolean conjugated) {
     List<SymTypeExpression> typeExpressions = new ArrayList<>();
 
-    for(var specialization : specializationList) {
+    for(var specialization: specializationList) {
       if(specialization instanceof ASTSysMLTyping && ((ASTSysMLTyping) specialization).isConjugated() == conjugated) {
         var astTyping = (ASTSysMLTyping) specialization;
 
-        for(var mcType : astTyping.getSuperTypesList()) {
+        for(var mcType: astTyping.getSuperTypesList()) {
           SymTypeExpression res = null;
           if(mcType instanceof ASTMCTupleType) {
             var tupleType = (ASTMCTupleType) mcType;
@@ -67,7 +67,7 @@ public class TypesCompleter implements SysMLBasisVisitor2, SysMLPartsVisitor2,
                 mcType.printType(),
                 (IBasicSymbolsScope) mcType.getEnclosingScope());
           }
-          else if (mcType.getDefiningSymbol().isPresent() && mcType.getDefiningSymbol().get() instanceof TypeSymbol) {
+          else if(mcType.getDefiningSymbol().isPresent() && mcType.getDefiningSymbol().get() instanceof TypeSymbol) {
             // hacky setup such that nat remains a primitive
             if (mcType.getDefiningSymbol().get().getName().equals("nat")) {
               res = SymTypeExpressionFactory.createPrimitive((TypeSymbol) mcType.getDefiningSymbol().get());
@@ -78,13 +78,13 @@ public class TypesCompleter implements SysMLBasisVisitor2, SysMLPartsVisitor2,
           else if(mcType.getDefiningSymbol().isEmpty()) {
             Log.warn("Defining symbol for " + mcType.printType() + " was not set.");
           }
-          else if (!(mcType.getDefiningSymbol().get() instanceof TypeSymbol)) {
+          else if(!(mcType.getDefiningSymbol().get() instanceof TypeSymbol)) {
             Log.warn("Defining symbol for " + mcType.printType() + " is not a TypeSymbol");
           }
 
           if(res != null) {
             if(astTyping.isPresentCardinality()) {
-              res = SymTypeExpressionFactory.createTypeArray(res.getTypeInfo(),1, res);
+              res = SymTypeExpressionFactory.createTypeArray(res.getTypeInfo(), 1, res);
             }
             typeExpressions.add(res);
           }
@@ -111,7 +111,7 @@ public class TypesCompleter implements SysMLBasisVisitor2, SysMLPartsVisitor2,
   public void visit(ASTPartUsage node) {
     List<SymTypeExpression> types = getTypeCompletion(node.getSpecializationList(), false);
 
-    if (node.isPresentSymbol()) {
+    if(node.isPresentSymbol()) {
       node.getSymbol().setTypesList(types);
     }
   }

--- a/language/src/test/java/typecheck/CalcDefAsFunctionTest.java
+++ b/language/src/test/java/typecheck/CalcDefAsFunctionTest.java
@@ -4,7 +4,7 @@ import de.monticore.lang.sysmlv2.SysMLv2Mill;
 import de.monticore.lang.sysmlv2.SysMLv2Tool;
 import de.monticore.lang.sysmlv2._cocos.SysMLv2CoCoChecker;
 import de.monticore.lang.sysmlv2.cocos.ConstraintIsBooleanTC3;
-import de.monticore.lang.sysmlv2.cocos.MaxOneDirectReturnInCalcUsageCoCo;
+import de.monticore.lang.sysmlv2.cocos.MaxOneDirectReturnInCalcDefCoCo;
 import de.se_rwth.commons.logging.Log;
 import de.se_rwth.commons.logging.LogStub;
 import org.junit.jupiter.api.Test;
@@ -12,21 +12,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * This class checks the implementation of SysML calc usages
+ * This class checks the implementation of SysML calc defs
  * as MontiCore function symbols. MontiCore establishes the
  * set of basic symbols as types, variables, and functions.
  * This is different from the plethora of SysML keywords that
  * are not meaningful for symbol resolution (and specifically
  * not relevant for type checking).
  */
-public class CalcUsageAsFunctionsTest {
-
+public class CalcDefAsFunctionTest {
   @Test
   public void testValid() throws Exception {
     LogStub.init();
     Log.clearFindings();
 
-    var model = "attribute def Foo { calc bar { return : boolean; } } \n" +
+    var model = "attribute def Foo { calc def bar { return : boolean; } } \n" +
         "attribute f: Foo; \n" +
         "constraint { f.bar() } \n";
 
@@ -42,7 +41,7 @@ public class CalcUsageAsFunctionsTest {
 
     SysMLv2CoCoChecker checker = new SysMLv2CoCoChecker();
     checker.addCoCo(new ConstraintIsBooleanTC3());
-    checker.addCoCo(new MaxOneDirectReturnInCalcUsageCoCo());
+    checker.addCoCo(new MaxOneDirectReturnInCalcDefCoCo());
     checker.checkAll(ast);
 
     assertTrue(Log.getFindings().isEmpty(), ()-> Log.getFindings().toString());
@@ -53,7 +52,7 @@ public class CalcUsageAsFunctionsTest {
     LogStub.init();
     Log.clearFindings();
 
-    var model = "attribute def Foo { calc bar { return : nat; } } \n" +
+    var model = "attribute def Foo { calc def bar { return : nat; } } \n" +
         "attribute f: Foo; \n" +
         "constraint { f.bar() } \n";
 
@@ -69,7 +68,7 @@ public class CalcUsageAsFunctionsTest {
 
     SysMLv2CoCoChecker checker = new SysMLv2CoCoChecker();
     checker.addCoCo(new ConstraintIsBooleanTC3());
-    checker.addCoCo(new MaxOneDirectReturnInCalcUsageCoCo());
+    checker.addCoCo(new MaxOneDirectReturnInCalcDefCoCo());
     checker.checkAll(ast);
 
     assertThat(Log.getFindings()).hasSize(1);


### PR DESCRIPTION
**Added**

- Added a test for handling SysML calc defs as function symbols.
- Added an adapter to treat CalcDef as function symbols.
- Added calculation for calc def in TypesCompleter
- Added a CoCo to check amount of return in calc def
- Added valid and invalid tests for type checking of calc def