### PR TITLE
Demo: SysMLFunctionOperatorExpr is wrapped within a CallExpression

### DIFF
--- a/language/src/main/grammars/de/monticore/lang/SysMLExpressions.mc4
+++ b/language/src/main/grammars/de/monticore/lang/SysMLExpressions.mc4
@@ -111,7 +111,7 @@ component grammar SysMLExpressions
    * name of the function to be invoked and an argument list for any remaining arguments (see 7.4.9.4). This is
    * useful for chaining invocations in an effective data flow
    */
-  SysMLFunctionOperationExpression implements Expression =
+  SysMLFunctionOperationExpression implements Expression <291> =
     Expression "->" Name ("(" (SysMLParameter || ",")* ")")? ("{" SysMLElement* inner:Expression "}")? ;
 
   // Eigentlich ist "^" der Name einer CalcDef aus den Domain Libraries

--- a/language/src/test/java/parser/ExpressionParserTest.java
+++ b/language/src/test/java/parser/ExpressionParserTest.java
@@ -88,6 +88,22 @@ public class ExpressionParserTest {
    * wrapped within a Call Expression
    */
   @Test
+  public void testSysMLFunctionOperatorExprMinimal() throws IOException {
+    var ast = parser.parse_StringExpression("x->b()");
+
+    assertThat(ast).isPresent();
+    assertThat(Log.getFindings()).isEmpty();
+    // We do expect: SysMLFunctionOperatorExpression with an inner
+    //  expression, name and parameters
+    // currently the parameters are separated in an outer CallExpr
+    assertThat(ast.get()).isInstanceOf(ASTSysMLFunctionOperationExpression.class);
+  }
+
+  /**
+   * Checks if SysMLFunctionOperatorExpressions are parsed without being
+   * wrapped within a Call Expression
+   */
+  @Test
   public void testSysMLFunctionOperatorExpr() throws IOException {
     var ast = parser.parse_StringExpression("x->excludes(y)");
 

--- a/language/src/test/java/parser/ExpressionParserTest.java
+++ b/language/src/test/java/parser/ExpressionParserTest.java
@@ -95,7 +95,6 @@ public class ExpressionParserTest {
     assertThat(Log.getFindings()).isEmpty();
     // We do expect: SysMLFunctionOperatorExpression with an inner
     //  expression, name and parameters
-    // currently the parameters are separated in an outer CallExpr
     assertThat(ast.get()).isInstanceOf(ASTSysMLFunctionOperationExpression.class);
   }
 
@@ -111,7 +110,6 @@ public class ExpressionParserTest {
     assertThat(Log.getFindings()).isEmpty();
     // We do expect: SysMLFunctionOperatorExpression with an inner
     //  expression, name and parameters
-    // currently the parameters are separated in an outer CallExpr
     assertThat(ast.get()).isInstanceOf(ASTSysMLFunctionOperationExpression.class);
   }
 

--- a/language/src/test/java/parser/ExpressionParserTest.java
+++ b/language/src/test/java/parser/ExpressionParserTest.java
@@ -2,6 +2,7 @@ package parser;
 
 import de.monticore.expressions.commonexpressions._ast.ASTCallExpression;
 import de.monticore.lang.sysmlexpressions._ast.ASTElementOfExpression;
+import de.monticore.lang.sysmlexpressions._ast.ASTSysMLFunctionOperationExpression;
 import de.monticore.lang.sysmlexpressions._ast.ASTSysMLInstantiation;
 import de.monticore.lang.sysmlv2.SysMLv2Mill;
 import de.monticore.lang.sysmlv2._parser.SysMLv2Parser;
@@ -80,6 +81,22 @@ public class ExpressionParserTest {
     assertThat(ast).isPresent();
     assertThat(Log.getFindings()).isEmpty();
     assertThat(ast.get()).isInstanceOf(ASTElementOfExpression.class);
+  }
+
+  /**
+   * Checks if SysMLFunctionOperatorExpressions are parsed without being
+   * wrapped within a Call Expression
+   */
+  @Test
+  public void testCallFunExpr() throws IOException {
+    var ast = parser.parse_StringExpression("x->excludes(y)");
+
+    assertThat(ast).isPresent();
+    assertThat(Log.getFindings()).isEmpty();
+    // We do expect: SysMLFunctionOperatorExpression with an inner
+    //  expression, name and parameters
+    // currently the parameters are separated in an outer CallExpr
+    assertThat(ast.get()).isInstanceOf(ASTSysMLFunctionOperationExpression.class);
   }
 
 }

--- a/language/src/test/java/parser/ExpressionParserTest.java
+++ b/language/src/test/java/parser/ExpressionParserTest.java
@@ -88,7 +88,7 @@ public class ExpressionParserTest {
    * wrapped within a Call Expression
    */
   @Test
-  public void testCallFunExpr() throws IOException {
+  public void testSysMLFunctionOperatorExpr() throws IOException {
     var ast = parser.parse_StringExpression("x->excludes(y)");
 
     assertThat(ast).isPresent();
@@ -98,5 +98,19 @@ public class ExpressionParserTest {
     // currently the parameters are separated in an outer CallExpr
     assertThat(ast.get()).isInstanceOf(ASTSysMLFunctionOperationExpression.class);
   }
+
+  @Test
+  public void testSysMLFunctionOperatorExpr2() throws IOException {
+    var ast = parser.parse_StringExpression("x->excludes(y.z)");
+
+    assertThat(ast).isPresent();
+    assertThat(Log.getFindings()).isEmpty();
+    // We do expect: SysMLFunctionOperatorExpression with an inner
+    //  expression, name and parameters
+    // currently the parameters are separated in an outer CallExpr
+    assertThat(ast.get()).isInstanceOf(ASTSysMLFunctionOperationExpression.class);
+  }
+
+  // ReachableStates(c.behavior, input2.values())->excludes(SecurityGate_LLR.behavior.Bob_Alice_Eve)
 
 }


### PR DESCRIPTION
demonstration purpose: failing test showing that SysMLFunctionOperatorExpr is wrapped within a argument containing CallExpression