### PR TITLE
Entferne das nicht-standardkonforme Keyword final aus den Modifiern und Modelen

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,4 +25,4 @@ assertj_version    = 3.21.0
 junit_version      = 5.8.2
 
 # Version of published artifacts
-version            = 7.8.49
+version            = 7.8.50

--- a/language/src/main/grammars/de/monticore/lang/SysMLBasis.mc4
+++ b/language/src/main/grammars/de/monticore/lang/SysMLBasis.mc4
@@ -224,8 +224,7 @@ component grammar SysMLBasis
       Stereotype?
       (   ["public"]       | [public:"+"]
         | ["private"]      | [private:"-"]
-        | ["protected"]    | {!noSpace(2)}? [protected:"#"]
-        | ["final"]
+        | ["protected"]    | [protected:"#"]
         | ["abstract"]
         | ["local"]
         | ["derived"]      | [derived:"/"]
@@ -243,10 +242,8 @@ component grammar SysMLBasis
         | ["variant"]
       )*;
 
-  nokeyword "final";
-
   UserDefinedKeyword =
-    {noSpace(2)}? "#" MCQualifiedName;
+    {noSpace(2);} "#" MCQualifiedName;
 
   /**
    * Anonyme Usage, deren "Typ" im Sinne der SysML (also Beispielsweise "attribute" oder "part") sich erst durch

--- a/language/src/main/grammars/de/monticore/lang/SysMLBasis.mc4
+++ b/language/src/main/grammars/de/monticore/lang/SysMLBasis.mc4
@@ -224,7 +224,7 @@ component grammar SysMLBasis
       Stereotype?
       (   ["public"]       | [public:"+"]
         | ["private"]      | [private:"-"]
-        | ["protected"]    | [protected:"#"]
+        | ["protected"]    | {!noSpace(2)}? [protected:"#"]
         | ["final"]
         | ["abstract"]
         | ["local"]
@@ -243,8 +243,10 @@ component grammar SysMLBasis
         | ["variant"]
       )*;
 
+  nokeyword "final";
+
   UserDefinedKeyword =
-    {noSpace(2);} "#" MCQualifiedName ;
+    {noSpace(2)}? "#" MCQualifiedName;
 
   /**
    * Anonyme Usage, deren "Typ" im Sinne der SysML (also Beispielsweise "attribute" oder "part") sich erst durch

--- a/language/src/main/grammars/de/monticore/lang/SysMLBasis.mc4
+++ b/language/src/main/grammars/de/monticore/lang/SysMLBasis.mc4
@@ -243,7 +243,7 @@ component grammar SysMLBasis
       )*;
 
   UserDefinedKeyword =
-    {noSpace(2);} "#" MCQualifiedName;
+    {noSpace(2);} "#" MCQualifiedName ;
 
   /**
    * Anonyme Usage, deren "Typ" im Sinne der SysML (also Beispielsweise "attribute" oder "part") sich erst durch

--- a/language/src/main/java/de/monticore/lang/sysmlv2/symboltable/adapters/PartDef2ComponentAdapter.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/symboltable/adapters/PartDef2ComponentAdapter.java
@@ -84,7 +84,6 @@ public class PartDef2ComponentAdapter extends MildComponentSymbol {
   public List<VariableSymbol> getParameterList() {
     return getAdaptee().getSpannedScope().getLocalAttributeUsageSymbols().stream()
         .filter(a -> a.isPresentAstNode())
-        .filter(a -> a.getAstNode().getModifier().isFinal())
         .map(a -> new AttributeUsage2VariableSymbolAdapter(a))
         .collect(Collectors.toList());
   }

--- a/language/src/main/java/de/monticore/lang/sysmlv2/symboltable/adapters/PartUsage2SubcomponentAdapter.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/symboltable/adapters/PartUsage2SubcomponentAdapter.java
@@ -49,7 +49,6 @@ public class PartUsage2SubcomponentAdapter extends MildInstanceSymbol {
   public List<ASTParameterValue> getParameterValuesList() {
     return getAdaptee().getSpannedScope().getLocalAttributeUsageSymbols().stream()
         .filter(a -> a.isPresentAstNode())
-        .filter(a -> a.getAstNode().getModifier().isFinal())
         .map(a -> new ParmeterValueWrapper(a, getAdaptee()))
         .collect(Collectors.toList());
   }

--- a/language/src/test/java/deser/ParameterDeserTest.java
+++ b/language/src/test/java/deser/ParameterDeserTest.java
@@ -16,7 +16,7 @@ public class ParameterDeserTest extends NervigeSymboltableTests {
 
   @Test
   public void testParameter() throws IOException {
-    var as = process("part def A { final attribute p: int; }");
+    var as = process("part def A { attribute p: int; }");
     setupComponentConnectorSerialization();
 
     var comp = as.resolveComponentType("A").get();

--- a/language/src/test/java/parser/ParseFinalAsNameParserTest.java
+++ b/language/src/test/java/parser/ParseFinalAsNameParserTest.java
@@ -1,0 +1,42 @@
+package parser;
+
+import de.monticore.lang.sysmlv2.SysMLv2Mill;
+import de.monticore.lang.sysmlv2._ast.ASTSysMLModel;
+import de.monticore.lang.sysmlv2._parser.SysMLv2Parser;
+import de.se_rwth.commons.logging.Log;
+import de.se_rwth.commons.logging.LogStub;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import java.io.IOException;
+import java.util.Optional;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+  public class ParseFinalAsNameParserTest {
+    @BeforeAll
+    public static void init() {
+      LogStub.init();
+      Log.enableFailQuick(false);
+      SysMLv2Mill.init();
+    }
+
+    /**
+     *  Modifier "final" should be able to be used as
+     *  a name.
+     */
+    void testFinalAsStateName() throws IOException {
+      Log.clearFindings();
+      SysMLv2Parser parser = SysMLv2Mill.parser();
+
+      var model = "state final : MissionComplete;";
+
+      Optional<ASTSysMLModel> ast = parser.parse_String(model);
+
+      assertFalse(parser.hasErrors(), "Parsing should not have failed");
+      assertTrue(ast.isPresent(), "The AST should have been created");
+      assertTrue(Log.getFindings().isEmpty(), "No parser findings expected");
+    }
+  }
+
+

--- a/language/src/test/java/parser/ParseFinalAsNameParserTest.java
+++ b/language/src/test/java/parser/ParseFinalAsNameParserTest.java
@@ -6,7 +6,6 @@ import de.monticore.lang.sysmlv2._parser.SysMLv2Parser;
 import de.se_rwth.commons.logging.Log;
 import de.se_rwth.commons.logging.LogStub;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.util.Optional;
@@ -25,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
      *  Modifier "final" should be able to be used as
      *  a name.
      */
+    @Test
     void testFinalAsStateName() throws IOException {
       Log.clearFindings();
       SysMLv2Parser parser = SysMLv2Mill.parser();

--- a/language/src/test/java/symboltable/ComponentTypeSymbolAdapterTest.java
+++ b/language/src/test/java/symboltable/ComponentTypeSymbolAdapterTest.java
@@ -31,7 +31,7 @@ public class ComponentTypeSymbolAdapterTest extends NervigeSymboltableTests {
 
   @Test
   public void testParameters() throws IOException {
-    var as = process("part def A { final attribute p: int; }");
+    var as = process("part def A { attribute p: int; }");
 
     var parameters = as.resolveMildComponent("A").get().getParameterList();
     assertThat(parameters).hasSize(1);
@@ -231,8 +231,8 @@ public class ComponentTypeSymbolAdapterTest extends NervigeSymboltableTests {
   @Test
   public void testParameterValues() throws IOException {
     var as = process(""
-        + "part def B { final attribute v: nat; }"
-        + "part def A { part b: B { final attribute v = 2; } }");
+        + "part def B { attribute v: nat; }"
+        + "part def A { part b: B { attribute v = 2; } }");
 
     var A = as.resolveMildComponent("A").get();
     var b = (MildInstanceSymbol)A.getSubcomponents("b").get();


### PR DESCRIPTION
**Removed**

- Entferne das nicht-standardkonforme Keyword `final` aus den Modifiern und Modelen

**Changed**

- Behandle Attribute ohne `final` als Parameter bzw. Parameterwert
