### PR TITLE
ActionSupertypes überschneidet nicht mehr mit SpecializationExistsTC3-CoCo

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,4 +25,4 @@ assertj_version    = 3.21.0
 junit_version      = 5.8.2
 
 # Version of published artifacts
-version            = 7.8.59
+version            = 7.8.60

--- a/language/src/main/java/de/monticore/lang/sysmlv2/cocos/ActionSupertypes.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/cocos/ActionSupertypes.java
@@ -19,33 +19,59 @@ public class ActionSupertypes implements SysMLActionsASTActionDefCoCo, SysMLActi
   }
 
   /**
-   * Check that all super types (specializations) exist. They need to be Action definitions.
+   * Checks that existing super types (specializations) of an ActionDef are Action definitions.
+   * Missing super types are ignored because they are reported by SpecializationExistsTC3.
    */
   @Override
   public void check(ASTActionDef node) {
-    var nonExistent = node.streamSpecializations()
+    var invalidSupertypes = node.streamSpecializations()
         .flatMap(s -> s.streamSuperTypes())
-        .filter(t -> node.getEnclosingScope().resolveActionDef(printName(t)).isEmpty())
+        .filter(t ->  {
+        String name = printName(t);
+
+        boolean exists =
+            node.getEnclosingScope().resolveType(name).isPresent()
+                || node.getEnclosingScope().resolveActionDef(name).isPresent()
+                || node.getEnclosingScope().resolveActionUsage(name).isPresent();
+
+        boolean isActionDef =
+            node.getEnclosingScope().resolveActionDef(name).isPresent();
+
+        return exists && !isActionDef;
+      })
         .collect(Collectors.toList());
 
-    for(var problem: nonExistent) {
-      Log.error("0x10017 Could not find Action definition \"" + printName(problem) + "\".");
+    for(var problem: invalidSupertypes) {
+      Log.error("0x10017 Specialization \"" + printName(problem) + "\" is not an Action definition.");
     }
   }
 
   /**
-   * Check that all super types (specializations) exist. They might be Action definitions or usages.
+   * Checks that existing super types (specializations) of an ActionUsage are Action definitions or usages.
+   * Missing super types are ignored because they are reported by SpecializationExistsTC3.
    */
   @Override
   public void check(ASTActionUsage node) {
-    var nonExistent = node.streamSpecializations()
+    var invalidSupertypes = node.streamSpecializations()
         .flatMap(s -> s.streamSuperTypes())
-        .filter(t -> node.getEnclosingScope().resolveActionDef(printName(t)).isEmpty()
-            && node.getEnclosingScope().resolveActionUsage(printName(t)).isEmpty())
+        .filter(t -> {
+        String name = printName(t);
+
+        boolean exists =
+            node.getEnclosingScope().resolveType(name).isPresent()
+                || node.getEnclosingScope().resolveActionDef(name).isPresent()
+                || node.getEnclosingScope().resolveActionUsage(name).isPresent();
+
+        boolean isAction =
+            node.getEnclosingScope().resolveActionDef(name).isPresent()
+                || node.getEnclosingScope().resolveActionUsage(name).isPresent();
+
+        return exists && !isAction;
+      })
         .collect(Collectors.toList());
 
-    for(var problem: nonExistent) {
-      Log.error("0x10020 Could not find Action definition or usage with the name \"" + printName(problem) + "\".");
+    for(var problem: invalidSupertypes) {
+      Log.error("0x10020 Specialization \"" + printName(problem) + "\" is not an Action definition or usage.");
     }
   }
 }

--- a/language/src/main/java/de/monticore/lang/sysmlv2/cocos/ActionSupertypes.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/cocos/ActionSupertypes.java
@@ -10,10 +10,9 @@ import de.se_rwth.commons.logging.Log;
 
 import java.util.stream.Collectors;
 
-// TODO Muss mit SpecialiationExists zusammenspielen, also darf der nicht
-//  anschlagen, wenn garkein Type existiert,
-// sondern nur, wenn zwar einer existiert, es aber keine
-// ActionDef/ActionUsage ist
+// Missing specializations are handled by SpecializationExistsTC3.
+// This CoCo only reports existing specializations with invalid action type.
+
 public class ActionSupertypes
     implements SysMLActionsASTActionDefCoCo, SysMLActionsASTActionUsageCoCo {
 

--- a/language/src/main/java/de/monticore/lang/sysmlv2/cocos/ActionSupertypes.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/cocos/ActionSupertypes.java
@@ -10,68 +10,78 @@ import de.se_rwth.commons.logging.Log;
 
 import java.util.stream.Collectors;
 
-// TODO Muss mit SpecialiationExists zusammenspielen, also darf der nicht anschlagen, wenn garkein Type existiert,
-// sondern nur, wenn zwar einer existiert, es aber keine ActionDef/ActionUsage ist
-public class ActionSupertypes implements SysMLActionsASTActionDefCoCo, SysMLActionsASTActionUsageCoCo {
+// TODO Muss mit SpecialiationExists zusammenspielen, also darf der nicht
+//  anschlagen, wenn garkein Type existiert,
+// sondern nur, wenn zwar einer existiert, es aber keine
+// ActionDef/ActionUsage ist
+public class ActionSupertypes
+    implements SysMLActionsASTActionDefCoCo, SysMLActionsASTActionUsageCoCo {
 
   private String printName(ASTMCType type) {
     return type.printType();
   }
 
   /**
-   * Checks that existing super types (specializations) of an ActionDef are Action definitions.
-   * Missing super types are ignored because they are reported by SpecializationExistsTC3.
+   * Checks that existing super types (specializations) of an ActionDef are
+   * Action definitions. Missing super types are ignored because they are
+   * reported by SpecializationExistsTC3.
    */
   @Override
   public void check(ASTActionDef node) {
     var invalidSupertypes = node.streamSpecializations()
         .flatMap(s -> s.streamSuperTypes())
-        .filter(t ->  {
-        String name = printName(t);
+        .filter(t -> {
+          String name = printName(t);
 
-        boolean exists =
-            node.getEnclosingScope().resolveType(name).isPresent()
-                || node.getEnclosingScope().resolveActionDef(name).isPresent()
-                || node.getEnclosingScope().resolveActionUsage(name).isPresent();
+          boolean exists =
+              node.getEnclosingScope().resolveType(name).isPresent()
+                  || node.getEnclosingScope().resolveActionDef(name).isPresent()
+                  || node.getEnclosingScope().resolveActionUsage(
+                  name).isPresent();
 
-        boolean isActionDef =
-            node.getEnclosingScope().resolveActionDef(name).isPresent();
+          boolean isActionDef =
+              node.getEnclosingScope().resolveActionDef(name).isPresent();
 
-        return exists && !isActionDef;
-      })
+          return exists && !isActionDef;
+        })
         .collect(Collectors.toList());
 
-    for(var problem: invalidSupertypes) {
-      Log.error("0x10017 Specialization \"" + printName(problem) + "\" is not an Action definition.");
+    for (var problem : invalidSupertypes) {
+      Log.error("0x10017 Specialization \"" + printName(problem)
+          + "\" is not an Action definition.");
     }
   }
 
   /**
-   * Checks that existing super types (specializations) of an ActionUsage are Action definitions or usages.
-   * Missing super types are ignored because they are reported by SpecializationExistsTC3.
+   * Checks that existing super types (specializations) of an ActionUsage are
+   * Action definitions or usages. Missing super types are ignored because they
+   * are reported by SpecializationExistsTC3.
    */
   @Override
   public void check(ASTActionUsage node) {
     var invalidSupertypes = node.streamSpecializations()
         .flatMap(s -> s.streamSuperTypes())
         .filter(t -> {
-        String name = printName(t);
+          String name = printName(t);
 
-        boolean exists =
-            node.getEnclosingScope().resolveType(name).isPresent()
-                || node.getEnclosingScope().resolveActionDef(name).isPresent()
-                || node.getEnclosingScope().resolveActionUsage(name).isPresent();
+          boolean exists =
+              node.getEnclosingScope().resolveType(name).isPresent()
+                  || node.getEnclosingScope().resolveActionDef(name).isPresent()
+                  || node.getEnclosingScope().resolveActionUsage(
+                  name).isPresent();
 
-        boolean isAction =
-            node.getEnclosingScope().resolveActionDef(name).isPresent()
-                || node.getEnclosingScope().resolveActionUsage(name).isPresent();
+          boolean isAction =
+              node.getEnclosingScope().resolveActionDef(name).isPresent()
+                  || node.getEnclosingScope().resolveActionUsage(
+                  name).isPresent();
 
-        return exists && !isAction;
-      })
+          return exists && !isAction;
+        })
         .collect(Collectors.toList());
 
-    for(var problem: invalidSupertypes) {
-      Log.error("0x10020 Specialization \"" + printName(problem) + "\" is not an Action definition or usage.");
+    for (var problem : invalidSupertypes) {
+      Log.error("0x10020 Specialization \"" + printName(problem)
+          + "\" is not an Action definition or usage.");
     }
   }
 }

--- a/language/src/test/java/cocos/ActionCoCosTest.java
+++ b/language/src/test/java/cocos/ActionCoCosTest.java
@@ -74,15 +74,36 @@ public class ActionCoCosTest {
     }
 
     @Test
-    public void testInvalid() throws IOException {
-      ASTSysMLModel ast = SysMLv2Mill.parser().parse_String("action def B: A;").get();
+    public void testInvalidActionDefSupertypeExistsButIsNotAction() throws IOException {
+      ASTSysMLModel ast = SysMLv2Mill.parser().parse_String("part def A; action def B: A;").get();
       SysMLv2Mill.scopesGenitorDelegator().createFromAST(ast);
       var checker = new SysMLv2CoCoChecker();
       checker.addCoCo((SysMLActionsASTActionDefCoCo) new ActionSupertypes());
       Log.enableFailQuick(false);
       checker.checkAll(ast);
       assertFalse(Log.getFindings().isEmpty());
+      assertTrue(Log.getFindings().stream()
+          .anyMatch(f -> f.getMsg().contains("0x10017")));
     }
+
+     @Test
+    public void testMissingActionDefSupertypeIsNotReportedByActionSupertypes() throws IOException {
+      ASTSysMLModel ast = SysMLv2Mill.parser()
+          .parse_String("action def B: A;")
+          .get();
+
+      SysMLv2Mill.scopesGenitorDelegator().createFromAST(ast);
+
+      var checker = new SysMLv2CoCoChecker();
+      checker.addCoCo((SysMLActionsASTActionDefCoCo) new ActionSupertypes());
+
+      Log.enableFailQuick(false);
+      checker.checkAll(ast);
+
+      assertTrue(Log.getFindings().stream()
+          .noneMatch(f -> f.getMsg().contains("0x10017")));
+    }
+    
   }
 
 }


### PR DESCRIPTION
## Changelog

##### Fixed

* Doppelte Error-Reporting bei Action-Spezialisierungen, meldet jetzt nur noch einmal
  - Wenn Name garnicht ex., dann meldet TC3-CoCo das Problem
  - Wenn die referenzierte Spezialisierung keine Action ist, dann meldet die hier gefixte CoCo das Problem