### PR TITLE
test apollo with default cocos and attempt to adapt the cocos

### DIFF
--- a/language/src/main/java/de/monticore/lang/sysmlv2/_symboltable/ISysMLv2Scope.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/_symboltable/ISysMLv2Scope.java
@@ -12,6 +12,7 @@ import de.monticore.lang.sysmlconstraints._ast.ASTRequirementUsage;
 import de.monticore.lang.sysmlconstraints._symboltable.RequirementSubjectSymbol;
 import de.monticore.lang.sysmlconstraints.symboltable.adapters.RequirementSubject2VariableSymbolAdapter;
 import de.monticore.lang.sysmlparts._ast.ASTSysMLImportStatement;
+import de.monticore.lang.sysmlparts._symboltable.PartDefSymbol;
 import de.monticore.lang.sysmlparts._symboltable.SysMLPackageSymbol;
 import de.monticore.lang.sysmloccurrences.symboltable.adapters.ItemDef2TypeSymbolAdapter;
 import de.monticore.lang.sysmloccurrences.symboltable.adapters.OccurrenceDef2TypeSymbolAdapter;
@@ -137,6 +138,138 @@ public interface ISysMLv2Scope extends ISysMLv2ScopeTOP {
         );
         result.addAll(resolvedEnclosing);
         foundSymbols = foundSymbols || !resolvedEnclosing.isEmpty();
+      }
+      /*
+       * Fallback for names that cannot safely be represented as a
+       * dot-qualified name, for example quoted SysML names containing dots.
+       *
+       * First try normal resolution. Only if that fails, resolve the imported
+       * package and search for the unchanged name inside its local scope.
+       */
+      if (result.isEmpty() && name.contains(".")) {
+        for (ImportStatement importStatement : importStatements) {
+          if (!importStatement.isStar()) {
+            continue;
+          }
+
+          var importedPackage = getEnclosingScope().resolveSysMLPackage(importStatement.getStatement());
+
+          if (importedPackage.isPresent()
+                  && importedPackage.get().getSpannedScope() instanceof ISysMLv2Scope
+          ) {
+            ISysMLv2Scope importedScope = (ISysMLv2Scope) importedPackage.get().getSpannedScope();
+
+            result.addAll(
+                importedScope.resolveTypeLocallyMany(
+                    false,
+                    name,
+                    modifier,
+                    predicate
+                )
+            );
+          }
+        }
+      }
+    }
+
+    return new ArrayList<>(result);
+  }
+
+  default void collectImportsFromScope(
+      ISysMLv2Scope scope,
+      List<ImportStatement> importStatements
+  ) {
+    if (scope == null || !scope.isPresentAstNode()) {
+      return;
+    }
+
+    var visitor = new SysMLPartsVisitor2() {
+      @Override
+      public void visit(ASTSysMLImportStatement node) {
+        // Only collect imports declared directly in this scope.
+        if (!scope.equals(node.getEnclosingScope())) {
+          return;
+        }
+
+        importStatements.add(new ImportStatement(node.getMCQualifiedName().getQName(),
+                node.isStar() || node.isRecursive()
+            )
+        );
+      }
+    };
+
+    var traverser = SysMLv2Mill.inheritanceTraverser();
+    traverser.add4SysMLParts(visitor);
+    scope.getAstNode().accept(traverser);
+  }
+
+  @Override
+  default List<PartDefSymbol> continuePartDefWithEnclosingScope(
+      boolean foundSymbols,
+      String name,
+      AccessModifier modifier,
+      Predicate<PartDefSymbol> predicate
+  ) {
+    final LinkedHashSet<PartDefSymbol> result = new LinkedHashSet<>();
+
+    if (checkIfContinueWithEnclosingScope(foundSymbols)
+            && getEnclosingScope() != null
+    ) {
+      var importStatements = new LinkedList<ImportStatement>();
+
+      /*
+       * The local search in this scope has already finished.
+       *
+       * Before continuing into the enclosing scope, apply the
+       * imports declared in the current scope.
+       */
+      collectImportsFromScope(this, importStatements);
+
+      Set<String> potentialNames = calcQNamesForEnclosingScope(name, importStatements);
+
+      for (String potentialName : potentialNames) {
+        var resolvedEnclosing = getEnclosingScope().resolvePartDefMany(
+            foundSymbols,
+            potentialName,
+            modifier,
+            predicate
+        );
+
+        result.addAll(resolvedEnclosing);
+
+        foundSymbols = foundSymbols || !resolvedEnclosing.isEmpty();
+      }
+
+      /*
+       * Fallback for names that cannot safely be represented as a
+       * dot-qualified name, for example quoted SysML names containing dots.
+       *
+       * First try normal resolution. Only if that fails, resolve the imported
+       * package and search for the unchanged name inside its local scope.
+       */
+      if (result.isEmpty() && name.contains(".")) {
+        for (ImportStatement importStatement : importStatements) {
+          if (!importStatement.isStar()) {
+            continue;
+          }
+
+          var importedPackage = getEnclosingScope().resolveSysMLPackage(importStatement.getStatement());
+
+          if (importedPackage.isPresent()
+                  && importedPackage.get().getSpannedScope() instanceof ISysMLv2Scope
+          ) {
+            ISysMLv2Scope importedScope = (ISysMLv2Scope) importedPackage.get().getSpannedScope();
+
+            result.addAll(
+                importedScope.resolvePartDefLocallyMany(
+                    false,
+                    name,
+                    modifier,
+                    predicate
+                )
+            );
+          }
+        }
       }
     }
 
@@ -277,7 +410,6 @@ public interface ISysMLv2Scope extends ISysMLv2ScopeTOP {
       potentialSymbolNames.add(this.getSpanningSymbol().getName() + "." + name);
     }
 
-    // import statements are not yet considered
 
     return potentialSymbolNames;
   }
@@ -650,6 +782,30 @@ public interface ISysMLv2Scope extends ISysMLv2ScopeTOP {
     });
 
     return adapted;
+  }
+
+//  The generated filter cannot correctly resolve quoted names containing
+//  dots, such as 'Roger B. Chaffee'. During resolution, the quotes are
+//  removed and the dots are interpreted as qualification separators.
+//  The override therefore checks all local PartDefSymbols directly and
+//  compares the requested name with both the symbol name and its full name.
+  @Override
+  default Optional<PartDefSymbol> filterPartDef(
+      String name,
+      LinkedListMultimap<String, PartDefSymbol> symbols
+  ) {
+    final Set<PartDefSymbol> resolvedSymbols = new LinkedHashSet<>();
+
+    for (PartDefSymbol symbol : symbols.values()) {
+      if (
+          symbol.getName().equals(name)
+              || symbol.getFullName().equals(name)
+      ) {
+        resolvedSymbols.add(symbol);
+      }
+    }
+
+    return getResolvedOrThrowException(resolvedSymbols);
   }
 
   // Alongside filtering for "name" and "fullname", we also filter for

--- a/language/src/main/java/de/monticore/lang/sysmlv2/cocos/NameCompatible4Isabelle.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/cocos/NameCompatible4Isabelle.java
@@ -27,7 +27,10 @@ public class NameCompatible4Isabelle implements SysMLStatesASTStateDefCoCo,
     SysMLPartsASTSysMLPackageCoCo {
   //check for name
   private void LogsCompatible4Isabelle(String name, SourcePosition start, SourcePosition end) {
-    if(!name.matches("^(?!0-9)[a-zA-Z0-9_]+$") && !name.isEmpty()) {
+    // Names must start with a letter or underscore.
+    // Subsequent characters may also include digits, spaces, dots, and hyphens.
+    // Name like 'Roger B. Chaffee' can be accepted.
+    if (!name.isEmpty() && !name.matches("^[a-zA-Z_][a-zA-Z0-9_ .-]*$")) {
       Log.error("0xFF005 This name is not Isabelle compatible", start, end);
     }
   }

--- a/language/src/main/java/de/monticore/lang/sysmlv2/cocos/PartTypeDefinitionExistsCoCo.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/cocos/PartTypeDefinitionExistsCoCo.java
@@ -6,7 +6,7 @@ import de.monticore.lang.sysmlparts._ast.ASTPartUsage;
 import de.monticore.lang.sysmlparts._cocos.SysMLPartsASTPartUsageCoCo;
 import de.monticore.types.mcbasictypes._ast.ASTMCType;
 import de.se_rwth.commons.logging.Log;
-
+import de.monticore.lang.sysmlbasis._ast.ASTSysMLTyping;
 import java.util.stream.Collectors;
 
 /**
@@ -21,6 +21,7 @@ public class PartTypeDefinitionExistsCoCo implements SysMLPartsASTPartUsageCoCo 
   @Override
   public void check(ASTPartUsage node) {
     var nonExistent = node.streamSpecializations()
+        .filter(s -> s instanceof ASTSysMLTyping)
         .flatMap(ASTSpecialization::streamSuperTypes)
         .filter(t ->
             node.getEnclosingScope().resolvePartDef(printPartType(t)).isEmpty()

--- a/language/src/main/java/de/monticore/lang/sysmlv2/cocos/UniqueSubPartNamesInParentCoCo.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/cocos/UniqueSubPartNamesInParentCoCo.java
@@ -16,6 +16,11 @@ public class UniqueSubPartNamesInParentCoCo implements SysMLPartsASTPartUsageCoC
 
     var scope = node.getEnclosingScope();
 
+   // Unnamed PartUsages are allowed and are ignored by this check.
+    if (!node.isPresentName()) {
+      return;
+    }
+
     String partName = node.getName();
 
     int matches = scope

--- a/language/src/test/java/parser/ApolloTest.java
+++ b/language/src/test/java/parser/ApolloTest.java
@@ -1,6 +1,8 @@
 package parser;
 
+import de.monticore.lang.sysmlv2.SysMLv2Mill;
 import de.monticore.lang.sysmlv2.SysMLv2Tool;
+import de.monticore.lang.sysmlv2._ast.ASTSysMLModel;
 import de.se_rwth.commons.logging.Log;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -8,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.stream.Collectors;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -42,9 +45,13 @@ public class ApolloTest {
     var lines = 0;
 
     Log.enableFailQuick(false);
+    var asts = new ArrayList<ASTSysMLModel>();
+
     for(var model: models) {
       try {
-        var ast = tool.parse(model.toString());
+        var ast = SysMLv2Mill.parser().parse(model.toString());
+        assertThat(ast).as("Could not parse " + model).isPresent();
+        asts.add(ast.get());
         if(Log.getFindings().isEmpty()) {
           successful++;
         }
@@ -56,9 +63,18 @@ public class ApolloTest {
         Log.clearFindings();
       }
     }
+    asts.forEach(ast -> tool.createSymbolTable(ast));
+    asts.forEach(ast -> tool.completeSymbolTable(ast));
+    asts.forEach(ast -> tool.finalizeSymbolTable(ast));
+
+    asts.forEach(ast -> tool.runDefaultCoCos(ast));
+    // asts.forEach(ast -> tool.runAdditionalCoCos(ast));
 
     assertThat(successful).isEqualTo(27);
     assertThat(Log.getFindings()).isEmpty();
+
+    var errors = Log.getFindings().stream().filter(f -> f.isError()).collect(Collectors.toList());
+    assertThat(errors).as(() -> Log.getFindings().toString()).isEmpty();
   }
 
 }

--- a/language/src/test/java/parser/ApolloTest.java
+++ b/language/src/test/java/parser/ApolloTest.java
@@ -68,7 +68,7 @@ public class ApolloTest {
     asts.forEach(ast -> tool.finalizeSymbolTable(ast));
 
     asts.forEach(ast -> tool.runDefaultCoCos(ast));
-    // asts.forEach(ast -> tool.runAdditionalCoCos(ast));
+    asts.forEach(ast -> tool.runAdditionalCoCos(ast));
 
     assertThat(successful).isEqualTo(27);
     assertThat(Log.getFindings()).isEmpty();


### PR DESCRIPTION
The Apollo-11 models can already be parsed(#146) . The symbol resolution and CoCos are adapted so that the models also pass the CoCos.

**Errors exposed by the CoCos:**

**0xFF005 — adapted** : Quoted SysML names may contain whitespace and dots, for example 'Roger B. Chaffee'. The name validation is extended to allow these valid names.

**0x10AA1 — adapted**: Imported PartDefs could not always be resolved for PartUsages. There were three main causes:
1. resolvePartDef() did not consider imports in the same way as type resolution.
2. Dots inside quoted names such as 'Roger B. Chaffee' were incorrectly interpreted as qualification separators.
3. Some imports belong to the current package scope, and were missed when only the enclosing scope was inspected.

**0xA7003x70648 — adapted**: The CoCo called getName() on unnamed PartUsages. Since unnamed PartUsages are valid, they are now ignored by this name check.

**0x10031 — to be adapted**: Referenced state definitions and state usages could not always be resolved.
**0x10AA2 — to be adapted**: Imported PartDefs used as refinement targets could not always be resolved.

## Changelog
### Added

* Added support for quoted SysML names containing whitespace and dots, such as `'Roger B. Chaffee'`.

### Changed

* Enabled `PartUsage`s to resolve `PartDef`s declared in imported packages.
* Extended import resolution to consider imports declared in the current package scope.
* Updated name checks to safely ignore unnamed `PartUsage`s.
