### PR TITLE
7.8.59: SysML-Funktionen mit Operatoren kompatibel machen

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,4 +25,4 @@ assertj_version    = 3.21.0
 junit_version      = 5.8.2
 
 # Version of published artifacts
-version            = 7.8.57
+version            = 7.8.59

--- a/language/src/main/java/de/monticore/lang/sysmlv2/types3/SysMLTypeVisitorOperatorCalculator.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/types3/SysMLTypeVisitorOperatorCalculator.java
@@ -33,6 +33,10 @@ public class SysMLTypeVisitorOperatorCalculator extends
     return type;
   }
 
+  /**
+   * calculates {@code +,-,%}
+   * without support for String
+   */
   @Override
   protected SymTypeExpression calculatePlusMinusModulo(
       SymTypeExpression left,
@@ -61,6 +65,9 @@ public class SysMLTypeVisitorOperatorCalculator extends
     return type;
   }
 
+  /**
+   * See Documentation in super class
+   */
   @Override
   protected SymTypeExpression calculateToString(
       SymTypeExpression inner
@@ -100,6 +107,10 @@ public class SysMLTypeVisitorOperatorCalculator extends
     return type;
   }
 
+  /**
+   * calculates {@code +,-,*,/,%}
+   * without support for String and SIUnits
+   */
   @Override
   protected SymTypeExpression calculateArithmeticExpressionNumeric(
       SymTypeExpression left,
@@ -117,6 +128,9 @@ public class SysMLTypeVisitorOperatorCalculator extends
     return type;
   }
 
+  /**
+   * calculates unary {@code +,-}
+   */
   @Override
   protected SymTypeExpression calculatePlusMinusPrefix(SymTypeExpression inner) {
     var type = super.calculatePlusMinusPrefix(inner);
@@ -126,6 +140,9 @@ public class SysMLTypeVisitorOperatorCalculator extends
     return type;
   }
 
+  /**
+   * calculates {@code ==, !=}
+   */
   @Override
   protected SymTypeExpression calculateEqualityInequality(
       SymTypeExpression left,
@@ -143,6 +160,9 @@ public class SysMLTypeVisitorOperatorCalculator extends
     return type;
   }
 
+  /**
+   * calculates {@code <, <=, >, =>}
+   */
   @Override
   protected SymTypeExpression calculateNumericComparison(
       SymTypeExpression left,
@@ -160,6 +180,9 @@ public class SysMLTypeVisitorOperatorCalculator extends
     return type;
   }
 
+  /**
+   * calculates {@code &&, ||}
+   */
   @Override
   protected SymTypeExpression calculateConditionalBooleanOp(
       SymTypeExpression left,
@@ -201,6 +224,9 @@ public class SysMLTypeVisitorOperatorCalculator extends
     return SymTypeExpressionFactory.createObscureType();
   }
 
+  /**
+   * calculates {@code &, |, ^}
+   */
   @Override
   protected SymTypeExpression calculateBinaryInfixOp(
       SymTypeExpression left,
@@ -215,6 +241,9 @@ public class SysMLTypeVisitorOperatorCalculator extends
     return type;
   }
 
+  /**
+   * calculates ~
+   */
   @Override
   protected SymTypeExpression calculateBitwiseComplement(SymTypeExpression inner) {
     var type = super.calculateBitwiseComplement(inner);
@@ -271,6 +300,13 @@ public class SysMLTypeVisitorOperatorCalculator extends
     return type;
   }
 
+  /**
+   * Returns the ReturnType of a FunctionType.
+   * TypeCheck3 returns the FunctionTypes signature (for "list.count()"
+   * TC3 would return "() -> int").
+   * So this is used to allow using functions directly with operators,
+   * effectively treating them as their return value.
+   */
   protected SymTypeExpression getFunctionReturnType(SymTypeExpression expression) {
     if (expression.isFunctionType()) {
       return expression.asFunctionType().getType();

--- a/language/src/main/java/de/monticore/lang/sysmlv2/types3/SysMLTypeVisitorOperatorCalculator.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/types3/SysMLTypeVisitorOperatorCalculator.java
@@ -20,18 +20,236 @@ public class SysMLTypeVisitorOperatorCalculator extends
   }
 
   @Override
+  protected SymTypeExpression calculatePlus(
+      SymTypeExpression left,
+      SymTypeExpression right
+  ) {
+    var type = super.calculatePlus(left, right);
+    if(type.isObscureType() &&
+      (left.isFunctionType() || right.isFunctionType())
+    ){
+      return super.calculatePlus(getFunctionReturnType(left), getFunctionReturnType(right));
+    }
+    return type;
+  }
+
+  @Override
+  protected SymTypeExpression calculatePlusMinusModulo(
+      SymTypeExpression left,
+      SymTypeExpression right
+  ) {
+    var type = super.calculatePlusMinusModulo(left, right);
+    if(type.isObscureType() &&
+      (left.isFunctionType() || right.isFunctionType())
+    ){
+      return super.calculatePlusMinusModulo(getFunctionReturnType(left), getFunctionReturnType(right));
+    }
+    return type;
+  }
+
+  @Override
+  protected SymTypeExpression calculatePlusString(
+      SymTypeExpression left,
+      SymTypeExpression right
+  ) {
+    var type = super.calculatePlusString(left, right);
+    if(type.isObscureType() &&
+      (left.isFunctionType() || right.isFunctionType())
+    ){
+      return super.calculatePlusString(getFunctionReturnType(left), getFunctionReturnType(right));
+    }
+    return type;
+  }
+
+  @Override
+  protected SymTypeExpression calculateToString(
+      SymTypeExpression inner
+  ) {
+    var type = super.calculateToString(inner);
+    if(type.isObscureType() && inner.isFunctionType()){
+      return super.calculateToString(getFunctionReturnType(inner));
+    }
+    return type;
+  }
+
+  @Override
+  protected SymTypeExpression calculateMultiply(
+      SymTypeExpression left,
+      SymTypeExpression right
+  ) {
+    var type = super.calculateMultiply(left, right);
+    if(type.isObscureType() &&
+      (left.isFunctionType() || right.isFunctionType())
+    ){
+      return super.calculateMultiply(getFunctionReturnType(left), getFunctionReturnType(right));
+    }
+    return type;
+  }
+
+  @Override
+  protected SymTypeExpression calculateDivide(
+      SymTypeExpression left,
+      SymTypeExpression right
+  ) {
+    var type = super.calculateDivide(left, right);
+    if(type.isObscureType() &&
+      (left.isFunctionType() || right.isFunctionType())
+    ){
+      return super.calculateDivide(getFunctionReturnType(left), getFunctionReturnType(right));
+    }
+    return type;
+  }
+
+  @Override
+  protected SymTypeExpression calculateArithmeticExpressionNumeric(
+      SymTypeExpression left,
+      SymTypeExpression right
+  ) {
+    var type = super.calculateArithmeticExpressionNumeric(left, right);
+    if(type.isObscureType() &&
+      (left.isFunctionType() || right.isFunctionType())
+    ){
+      return super.calculateArithmeticExpressionNumeric(
+          getFunctionReturnType(left),
+          getFunctionReturnType(right)
+      );
+    }
+    return type;
+  }
+
+  @Override
+  protected SymTypeExpression calculatePlusMinusPrefix(SymTypeExpression inner) {
+    var type = super.calculatePlusMinusPrefix(inner);
+    if(type.isObscureType() && inner.isFunctionType()){
+      return super.calculatePlusMinusPrefix(getFunctionReturnType(inner));
+    }
+    return type;
+  }
+
+  @Override
+  protected SymTypeExpression calculateEqualityInequality(
+      SymTypeExpression left,
+      SymTypeExpression right
+  ) {
+    var type = super.calculateEqualityInequality(left, right);
+    if(type.isObscureType() &&
+      (left.isFunctionType() || right.isFunctionType())
+    ){
+      return super.calculateEqualityInequality(
+          getFunctionReturnType(left),
+          getFunctionReturnType(right)
+      );
+    }
+    return type;
+  }
+
+  @Override
+  protected SymTypeExpression calculateNumericComparison(
+      SymTypeExpression left,
+      SymTypeExpression right
+  ) {
+    var type = super.calculateNumericComparison(left, right);
+    if(type.isObscureType() &&
+      (left.isFunctionType() || right.isFunctionType())
+    ){
+      return super.calculateNumericComparison(
+          getFunctionReturnType(left),
+          getFunctionReturnType(right)
+      );
+    }
+    return type;
+  }
+
+  @Override
+  protected SymTypeExpression calculateConditionalBooleanOp(
+      SymTypeExpression left,
+      SymTypeExpression right
+  ) {
+    var type = super.calculateConditionalBooleanOp(left, right);
+    if(type.isObscureType() &&
+      (left.isFunctionType() || right.isFunctionType())
+    ){
+      return super.calculateConditionalBooleanOp(
+          getFunctionReturnType(left),
+          getFunctionReturnType(right)
+      );
+    }
+    return type;
+  }
+
+  @Override
   protected SymTypeExpression calculateLogicalNot(SymTypeExpression inner) {
+    SymTypeExpression unpacked = getFunctionReturnType(inner);
     var result = super.calculateLogicalNot(inner);
+    var unpackedResult = super.calculateLogicalNot(getFunctionReturnType(inner));
     if (SymTypeRelations.isBoolean(result)) {
       return result;
+    } else if (SymTypeRelations.isBoolean(unpackedResult)) {
+      return unpackedResult;
     }
     // TODO resolve for Stream and deepEquals
     else if (inner.hasTypeInfo() && inner.getTypeInfo().isPresentSuperClass() &&
         inner.getTypeInfo().getSuperClass().print().equals("Stream<T>")) {
       return inner;
     }
+    else if (unpacked.hasTypeInfo() &&
+        unpacked.getTypeInfo().isPresentSuperClass() &&
+        unpacked.getTypeInfo().getSuperClass().print().equals("Stream<T>")) {
+      return unpacked;
+    }
 
     return SymTypeExpressionFactory.createObscureType();
+  }
+
+  @Override
+  protected SymTypeExpression calculateBinaryInfixOp(
+      SymTypeExpression left,
+      SymTypeExpression right
+  ) {
+    var type = super.calculateBinaryInfixOp(left, right);
+    if(type.isObscureType() &&
+      (left.isFunctionType() || right.isFunctionType())
+    ){
+      return super.calculateBinaryInfixOp(getFunctionReturnType(left), getFunctionReturnType(right));
+    }
+    return type;
+  }
+
+  @Override
+  protected SymTypeExpression calculateBitwiseComplement(SymTypeExpression inner) {
+    var type = super.calculateBitwiseComplement(inner);
+    if(type.isObscureType() && inner.isFunctionType()){
+      return super.calculateBitwiseComplement(getFunctionReturnType(inner));
+    }
+    return type;
+  }
+
+  @Override
+  protected SymTypeExpression calculateShift(
+      SymTypeExpression left,
+      SymTypeExpression right
+  ) {
+    var type = super.calculateShift(left, right);
+    if(type.isObscureType() &&
+      (left.isFunctionType() || right.isFunctionType())
+    ){
+      return super.calculateShift(getFunctionReturnType(left), getFunctionReturnType(right));
+    }
+    return type;
+  }
+
+  @Override
+  protected SymTypeExpression calculateAssignment(
+      SymTypeExpression left,
+      SymTypeExpression right
+  ) {
+    var type = super.calculateAssignment(left, right);
+    if(type.isObscureType() &&
+      (left.isFunctionType() || right.isFunctionType())
+    ){
+      return super.calculateAssignment(getFunctionReturnType(left), getFunctionReturnType(right));
+    }
+    return type;
   }
 
   public static Optional<SymTypeExpression> conditionalNot(SymTypeExpression inner) {
@@ -46,6 +264,19 @@ public class SysMLTypeVisitorOperatorCalculator extends
   }
 
   protected SymTypeExpression calculateConditionalNot(SymTypeExpression inner) {
-    return super.calculateLogicalNot(inner);
+    var type = super.calculateLogicalNot(inner);
+    if(type.isObscureType() && inner.isFunctionType()){
+      return super.calculateLogicalNot(getFunctionReturnType(inner));
+    }
+    return type;
   }
+
+  protected SymTypeExpression getFunctionReturnType(SymTypeExpression expression) {
+    if (expression.isFunctionType()) {
+      return expression.asFunctionType().getType();
+    }
+    return expression;
+  }
+
+
 }


### PR DESCRIPTION
## Changed
* SysML-Funktionen (wie z.B. list.count()) mit Numerischen-Operatoren und Boolschen-Operatoren in Expressions kompatibel machen, durch Fallback mit automatischem entpacken des Rückgabetypen

## Problem
* TC3 mit ConstraintIsBooleanTC3 warf Fehler bei folgendem Modell
```
part def MyPart {
  attribute list: List<String>;
  require constraint {
    list.count > 0
  }
}
```
Ausdruck list.count wurde korrekt als Funktionstyp `() -> int`  aufgelöst. aber Operator-Calculator erkennt einen Konflikt zwischen:
* Linker Seite: `() -> int` 
* Rechter Seite: `int`

Diese Inkompatibilität betraf nicht nur den Vergleichsoperator `>`.
## Lösung
* Füge einen FallBack hinzu, welcher beim zweiten Versuch Funktionen nun auf ihre RückgabeTypen auflöst