### PR TITLE
unamed  part usages are allowed

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,4 +25,4 @@ assertj_version    = 3.21.0
 junit_version      = 5.8.2
 
 # Version of published artifacts
-version            = 7.8.57
+version            = 7.8.58

--- a/language/src/main/java/de/monticore/lang/sysmlv2/cocos/UniqueSubPartNamesInParentCoCo.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/cocos/UniqueSubPartNamesInParentCoCo.java
@@ -16,6 +16,11 @@ public class UniqueSubPartNamesInParentCoCo implements SysMLPartsASTPartUsageCoC
 
     var scope = node.getEnclosingScope();
 
+    // Unnamed PartUsages are allowed and are ignored by this check.
+    if (!node.isPresentName()) {
+      return;
+    }
+
     String partName = node.getName();
 
     int matches = scope


### PR DESCRIPTION
##### Fixed

* Anonyme PartUsages haben zu Crashes bei der Überprüfung der Eindeutigkeit des Namens geführt
   - Werden jetzt von der CoCo ignoriert