### PR TITLE
Ln/check only part typings

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,4 +25,4 @@ assertj_version    = 3.21.0
 junit_version      = 5.8.2
 
 # Version of published artifacts
-version            = 7.8.58
+version            = 7.8.59

--- a/language/src/main/java/de/monticore/lang/sysmlv2/cocos/PartTypeDefinitionExistsCoCo.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/cocos/PartTypeDefinitionExistsCoCo.java
@@ -2,6 +2,7 @@
 package de.monticore.lang.sysmlv2.cocos;
 
 import de.monticore.lang.sysmlbasis._ast.ASTSpecialization;
+import de.monticore.lang.sysmlbasis._ast.ASTSysMLTyping;
 import de.monticore.lang.sysmlparts._ast.ASTPartUsage;
 import de.monticore.lang.sysmlparts._cocos.SysMLPartsASTPartUsageCoCo;
 import de.monticore.types.mcbasictypes._ast.ASTMCType;
@@ -21,6 +22,7 @@ public class PartTypeDefinitionExistsCoCo implements SysMLPartsASTPartUsageCoCo 
   @Override
   public void check(ASTPartUsage node) {
     var nonExistent = node.streamSpecializations()
+        .filter(s -> s instanceof ASTSysMLTyping)
         .flatMap(ASTSpecialization::streamSuperTypes)
         .filter(t ->
             node.getEnclosingScope().resolvePartDef(printPartType(t)).isEmpty()


### PR DESCRIPTION
### Fixed 
* Fixed `PartTypeDefinitionExistsCoCo` to check only typing relations and not treat subsetting targets as part definitions.
