### PR TITLE
Add constant modifier to SysML grammar

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,4 +25,4 @@ assertj_version    = 3.21.0
 junit_version      = 5.8.2
 
 # Version of published artifacts
-version            = 7.8.59
+version            = 7.8.60

--- a/language/src/main/grammars/de/monticore/lang/SysMLBasis.mc4
+++ b/language/src/main/grammars/de/monticore/lang/SysMLBasis.mc4
@@ -226,6 +226,7 @@ component grammar SysMLBasis
         | ["private"]      | [private:"-"]
         | ["protected"]    | [protected:"#"]
         | ["abstract"]
+        | ["constant"]
         | ["local"]
         | ["derived"]      | [derived:"/"]
         | ["readonly"]     | [readonly:"?"]


### PR DESCRIPTION
Adds parsing support for the SysML `constant` modifier by adding it to the central `Modifier` production in `SysMLBasis.mc4`