### PR TITLE
7.8.61 Import-Logik findet jetzt die korrekten Imports (#343)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,4 +25,4 @@ assertj_version    = 3.21.0
 junit_version      = 5.8.2
 
 # Version of published artifacts
-version            = 7.8.60
+version            = 7.8.61

--- a/language/src/main/java/de/monticore/lang/sysmlv2/_symboltable/ISysMLv2Scope.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/_symboltable/ISysMLv2Scope.java
@@ -114,11 +114,11 @@ public interface ISysMLv2Scope extends ISysMLv2ScopeTOP {
     ) {
 
       var importStatements = new LinkedList<ImportStatement>();
-      if(getEnclosingScope().isPresentAstNode()) {
+      if(this.isPresentAstNode()) {
         var visitor = new SysMLPartsVisitor2() {
           @Override
           public void visit(ASTSysMLImportStatement node) {
-            if (getEnclosingScope().equals(node.getEnclosingScope())) {
+            if (node.getEnclosingScope().equals(ISysMLv2Scope.this)) {
               importStatements.add(new ImportStatement(node.getMCQualifiedName().getQName(),
                   node.isStar() || node.isRecursive()));
             }
@@ -126,7 +126,7 @@ public interface ISysMLv2Scope extends ISysMLv2ScopeTOP {
         };
         var traverser = SysMLv2Mill.inheritanceTraverser();
         traverser.add4SysMLParts(visitor);
-        getEnclosingScope().getAstNode().accept(traverser);
+        this.getAstNode().accept(traverser);
       }
 
       Set<String> potentialNames = calcQNamesForEnclosingScope(name, importStatements);
@@ -162,11 +162,11 @@ public interface ISysMLv2Scope extends ISysMLv2ScopeTOP {
     ) {
 
       var importStatements = new LinkedList<ImportStatement>();
-      if(getEnclosingScope().isPresentAstNode()) {
+      if(this.isPresentAstNode()) {
         var visitor = new SysMLPartsVisitor2() {
           @Override
           public void visit(ASTSysMLImportStatement node) {
-            if (getEnclosingScope().equals(node.getEnclosingScope())) {
+            if (node.getEnclosingScope().equals(ISysMLv2Scope.this)) {
               importStatements.add(new ImportStatement(node.getMCQualifiedName().getQName(),
                   node.isStar() || node.isRecursive()));
             }
@@ -174,7 +174,7 @@ public interface ISysMLv2Scope extends ISysMLv2ScopeTOP {
         };
         var traverser = SysMLv2Mill.inheritanceTraverser();
         traverser.add4SysMLParts(visitor);
-        getEnclosingScope().getAstNode().accept(traverser);
+        this.getAstNode().accept(traverser);
       }
 
       Set<String> potentialNames = calcQNamesForEnclosingScope(name, importStatements);
@@ -210,11 +210,11 @@ public interface ISysMLv2Scope extends ISysMLv2ScopeTOP {
     ) {
 
       var importStatements = new LinkedList<ImportStatement>();
-      if(getEnclosingScope().isPresentAstNode()) {
+      if(this.isPresentAstNode()) {
         var visitor = new SysMLPartsVisitor2() {
           @Override
           public void visit(ASTSysMLImportStatement node) {
-            if (getEnclosingScope().equals(node.getEnclosingScope())) {
+            if (node.getEnclosingScope().equals(ISysMLv2Scope.this)) {
               importStatements.add(new ImportStatement(node.getMCQualifiedName().getQName(),
                   node.isStar() || node.isRecursive()));
             }
@@ -222,7 +222,7 @@ public interface ISysMLv2Scope extends ISysMLv2ScopeTOP {
         };
         var traverser = SysMLv2Mill.inheritanceTraverser();
         traverser.add4SysMLParts(visitor);
-        getEnclosingScope().getAstNode().accept(traverser);
+        this.getAstNode().accept(traverser);
       }
 
       Set<String> potentialNames = calcQNamesForEnclosingScope(name, importStatements);

--- a/language/src/main/java/de/monticore/lang/sysmlv2/_symboltable/ISysMLv2Scope.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/_symboltable/ISysMLv2Scope.java
@@ -113,22 +113,7 @@ public interface ISysMLv2Scope extends ISysMLv2ScopeTOP {
       && getEnclosingScope() != null
     ) {
 
-      var importStatements = new LinkedList<ImportStatement>();
-      if(this.isPresentAstNode()) {
-        var visitor = new SysMLPartsVisitor2() {
-          @Override
-          public void visit(ASTSysMLImportStatement node) {
-            if (node.getEnclosingScope().equals(ISysMLv2Scope.this)) {
-              importStatements.add(new ImportStatement(node.getMCQualifiedName().getQName(),
-                  node.isStar() || node.isRecursive()));
-            }
-          }
-        };
-        var traverser = SysMLv2Mill.inheritanceTraverser();
-        traverser.add4SysMLParts(visitor);
-        this.getAstNode().accept(traverser);
-      }
-
+      var importStatements = findImports();
       Set<String> potentialNames = calcQNamesForEnclosingScope(name, importStatements);
 
       for (String potentialName : potentialNames) {
@@ -143,6 +128,30 @@ public interface ISysMLv2Scope extends ISysMLv2ScopeTOP {
     }
 
     return new ArrayList<>(result);
+  }
+
+  default List<ImportStatement> findImports() {
+    var importStatements = new LinkedList<ImportStatement>();
+
+    if (this.isPresentAstNode()) {
+      var visitor = new SysMLPartsVisitor2() {
+        @Override
+        public void visit(ASTSysMLImportStatement node) {
+          if (node.getEnclosingScope().equals(ISysMLv2Scope.this)) {
+            importStatements.add(new ImportStatement(
+                node.getMCQualifiedName().getQName(),
+                node.isStar() || node.isRecursive()
+            ));
+          }
+        }
+      };
+
+      var traverser = SysMLv2Mill.inheritanceTraverser();
+      traverser.add4SysMLParts(visitor);
+      this.getAstNode().accept(traverser);
+    }
+
+    return importStatements;
   }
 
   /**
@@ -161,22 +170,7 @@ public interface ISysMLv2Scope extends ISysMLv2ScopeTOP {
       && getEnclosingScope() != null
     ) {
 
-      var importStatements = new LinkedList<ImportStatement>();
-      if(this.isPresentAstNode()) {
-        var visitor = new SysMLPartsVisitor2() {
-          @Override
-          public void visit(ASTSysMLImportStatement node) {
-            if (node.getEnclosingScope().equals(ISysMLv2Scope.this)) {
-              importStatements.add(new ImportStatement(node.getMCQualifiedName().getQName(),
-                  node.isStar() || node.isRecursive()));
-            }
-          }
-        };
-        var traverser = SysMLv2Mill.inheritanceTraverser();
-        traverser.add4SysMLParts(visitor);
-        this.getAstNode().accept(traverser);
-      }
-
+      var importStatements = findImports();
       Set<String> potentialNames = calcQNamesForEnclosingScope(name, importStatements);
 
       for (String potentialName : potentialNames) {
@@ -209,22 +203,7 @@ public interface ISysMLv2Scope extends ISysMLv2ScopeTOP {
       && (getEnclosingScope() != null)
     ) {
 
-      var importStatements = new LinkedList<ImportStatement>();
-      if(this.isPresentAstNode()) {
-        var visitor = new SysMLPartsVisitor2() {
-          @Override
-          public void visit(ASTSysMLImportStatement node) {
-            if (node.getEnclosingScope().equals(ISysMLv2Scope.this)) {
-              importStatements.add(new ImportStatement(node.getMCQualifiedName().getQName(),
-                  node.isStar() || node.isRecursive()));
-            }
-          }
-        };
-        var traverser = SysMLv2Mill.inheritanceTraverser();
-        traverser.add4SysMLParts(visitor);
-        this.getAstNode().accept(traverser);
-      }
-
+      var importStatements = findImports();
       Set<String> potentialNames = calcQNamesForEnclosingScope(name, importStatements);
 
       for (String potentialName : potentialNames) {

--- a/language/src/main/java/de/monticore/lang/sysmlv2/_symboltable/SysMLv2ArtifactScope.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/_symboltable/SysMLv2ArtifactScope.java
@@ -1,5 +1,9 @@
 package de.monticore.lang.sysmlv2._symboltable;
 
+import de.monticore.symboltable.ImportStatement;
+
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 public class SysMLv2ArtifactScope extends SysMLv2ArtifactScopeTOP {
@@ -16,4 +20,10 @@ public class SysMLv2ArtifactScope extends SysMLv2ArtifactScopeTOP {
     return super.getName();
   }
 
+  @Override
+  public List<ImportStatement> getImportsList() {
+    var imports = new ArrayList<>(super.getImportsList());
+    imports.addAll(findImports());
+    return imports;
+  }
 }

--- a/language/src/test/java/cocos/SpecializationExistsCoCoTest.java
+++ b/language/src/test/java/cocos/SpecializationExistsCoCoTest.java
@@ -13,6 +13,7 @@ import de.se_rwth.commons.logging.Log;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -77,6 +78,19 @@ public class SpecializationExistsCoCoTest {
     createSt(ast);
     var errors = check(ast);
     assertThat(errors).hasSize(0);
+  }
+
+  @Disabled("Die CoCo sucht 'P' im enclosing Scope von ':P', was dem der Part "
+      + "Usage entspricht.")
+  @Test
+  public void testInvalid() throws IOException {
+    var model = "part p: P { part def P; }";
+    var ast = parse(model);
+    createSt(ast);
+    var errors = check(ast);
+
+    assertThat(errors).hasSize(1);
+    assertThat(errors.get(0).getMsg()).contains("0xA0324");
   }
 
   private ASTSysMLModel parse(String model) throws IOException {

--- a/language/src/test/java/symboltable/ImportResolveTest.java
+++ b/language/src/test/java/symboltable/ImportResolveTest.java
@@ -281,4 +281,86 @@ public class ImportResolveTest {
     assertThat(optParent.get().getFullName()).isEqualTo("Other.InnerOther.Parent");
   }
 
+  /** Prüft, dass ein Import die korrekten Variablen sichtbar macht */
+  @Disabled("Es fehlt ein PartUsage2VariableAdapter")
+  @Test
+  public void testVisibilityOfVariables() throws IOException {
+    LogStub.init();
+    var tool = new SysMLv2Tool();
+    tool.init();
+
+    var parentModel = "package o { part p; }";
+    var model = "package test { import o::*; }";
+
+    var parentAst = SysMLv2Mill.parser().parse_String(parentModel).get();
+    tool.createSymbolTable(parentAst);
+    tool.completeSymbolTable(parentAst);
+    tool.finalizeSymbolTable(parentAst);
+
+    var ast = SysMLv2Mill.parser().parse_String(model).get();
+    tool.createSymbolTable(ast);
+    tool.completeSymbolTable(ast);
+    tool.finalizeSymbolTable(ast);
+
+    var scope = ((ASTSysMLPackage)ast.getSysMLElement(0)).getSpannedScope();
+    var p = scope.resolveVariable("p");
+
+    assertThat(p).isPresent();
+    assertThat(p.get().getFullName()).isEqualTo("o.p");
+  }
+
+  /** Prüft, dass ein Import die korrekten Typen sichtbar macht */
+  @Test
+  public void testVisibilityOfTypes() throws IOException {
+    LogStub.init();
+    var tool = new SysMLv2Tool();
+    tool.init();
+
+    var parentModel = "package o { part def P; }";
+    var model = "package test { import o::*; }";
+
+    var parentAst = SysMLv2Mill.parser().parse_String(parentModel).get();
+    tool.createSymbolTable(parentAst);
+    tool.completeSymbolTable(parentAst);
+    tool.finalizeSymbolTable(parentAst);
+
+    var ast = SysMLv2Mill.parser().parse_String(model).get();
+    tool.createSymbolTable(ast);
+    tool.completeSymbolTable(ast);
+    tool.finalizeSymbolTable(ast);
+
+    var scope = ((ASTSysMLPackage)ast.getSysMLElement(0)).getSpannedScope();
+    var p = scope.resolveType("P");
+
+    assertThat(p).isPresent();
+    assertThat(p.get().getFullName()).isEqualTo("o.P");
+  }
+
+  /** Prüft, dass ein Import die korrekten Funktionen sichtbar macht */
+  @Test
+  public void testVisibilityOfFunctions() throws IOException {
+    LogStub.init();
+    var tool = new SysMLv2Tool();
+    tool.init();
+
+    var parentModel = "package o { calc def C; }";
+    var model = "package test { import o::*; }";
+
+    var parentAst = SysMLv2Mill.parser().parse_String(parentModel).get();
+    tool.createSymbolTable(parentAst);
+    tool.completeSymbolTable(parentAst);
+    tool.finalizeSymbolTable(parentAst);
+
+    var ast = SysMLv2Mill.parser().parse_String(model).get();
+    tool.createSymbolTable(ast);
+    tool.completeSymbolTable(ast);
+    tool.finalizeSymbolTable(ast);
+
+    var scope = ((ASTSysMLPackage)ast.getSysMLElement(0)).getSpannedScope();
+    var p = scope.resolveFunction("C");
+
+    assertThat(p).isPresent();
+    assertThat(p.get().getFullName()).isEqualTo("o.C");
+  }
+
 }


### PR DESCRIPTION
##### Fixed

* Import-Logik suchte vorher nach Imports im enclosingScope und hat dadurch die Imports des aktuellen Scopes übersprungen. Das ist bisher nicht aufgefallen, da die Spezialisierungen **im** Scope ihres SysMLElements liegen und die enstprechenenden CoCos in den enclosing Scopes der Spezialisierung suchen und damit ein Level zu weit unten. 