### PR TITLE
7.8.63: TypeCheck für ControlFunctions-Operatoren 'and' und 'or' erweitert

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,4 +25,4 @@ assertj_version    = 3.21.0
 junit_version      = 5.8.2
 
 # Version of published artifacts
-version            = 7.8.62
+version            = 7.8.63

--- a/language/src/main/java/de/monticore/lang/sysmlv2/types3/SysMLOCLExpressionsTypeVisitor.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/types3/SysMLOCLExpressionsTypeVisitor.java
@@ -1,6 +1,8 @@
 package de.monticore.lang.sysmlv2.types3;
 
+import de.monticore.lang.sysmlexpressions._ast.ASTConditionalAndExpression;
 import de.monticore.lang.sysmlexpressions._ast.ASTConditionalAndExpression2;
+import de.monticore.lang.sysmlexpressions._ast.ASTConditionalOrExpression;
 import de.monticore.lang.sysmlexpressions._ast.ASTConditionalOrExpression2;
 import de.monticore.lang.sysmlexpressions._ast.ASTExistsExpression;
 import de.monticore.lang.sysmlexpressions._visitor.SysMLExpressionsVisitor2;
@@ -31,9 +33,32 @@ public class SysMLOCLExpressionsTypeVisitor extends OCLExpressionsTypeVisitor im
             .apply(left, right);
     getType4Ast().setTypeOfExpression(expr, result);
   }
+  @Override
+  public void endVisit(ASTConditionalAndExpression expr) {
+    SymTypeExpression left = getType4Ast().getPartialTypeOfExpr(expr.getLeft());
+    SymTypeExpression right = getType4Ast().getPartialTypeOfExpr(expr.getRight());
+
+    SymTypeExpression result =
+        TypeVisitorLifting.liftDefault(
+                this::calculateBooleanBinaryExpression)
+            .apply(left, right);
+    getType4Ast().setTypeOfExpression(expr, result);
+  }
 
   @Override
   public void endVisit(ASTConditionalOrExpression2 expr) {
+    SymTypeExpression left = getType4Ast().getPartialTypeOfExpr(expr.getLeft());
+    SymTypeExpression right = getType4Ast().getPartialTypeOfExpr(expr.getRight());
+
+    SymTypeExpression result =
+        TypeVisitorLifting.liftDefault(
+                this::calculateBooleanBinaryExpression)
+            .apply(left, right);
+    getType4Ast().setTypeOfExpression(expr, result);
+  }
+
+  @Override
+  public void endVisit(ASTConditionalOrExpression expr) {
     SymTypeExpression left = getType4Ast().getPartialTypeOfExpr(expr.getLeft());
     SymTypeExpression right = getType4Ast().getPartialTypeOfExpr(expr.getRight());
 


### PR DESCRIPTION
## Changed
* TypeVisitor unterstützt nun die Operatoren 'and' und 'or' analog zu '&' und '|'