### PR TITLE
Visitor für falsche Specialization Interpretation

### DIFF
--- a/language/src/main/java/de/monticore/lang/sysmlv2/visitors/SpecializationToSubsettingVisitor.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/visitors/SpecializationToSubsettingVisitor.java
@@ -1,101 +1,53 @@
 package de.monticore.lang.sysmlv2.visitors;
 
 import de.monticore.lang.sysmlbasis._ast.ASTSpecialization;
-import de.monticore.lang.sysmlbasis._ast.ASTSysMLElement;
 import de.monticore.lang.sysmlbasis._ast.ASTSysMLSpecialization;
 import de.monticore.lang.sysmlbasis._ast.ASTSysMLSubsetting;
-import de.monticore.lang.sysmlbasis._ast.ASTSysMLType;
-import de.monticore.lang.sysmlbasis._visitor.SysMLBasisVisitor2;
 import de.monticore.lang.sysmlparts._ast.ASTAttributeUsage;
 import de.monticore.lang.sysmlparts._visitor.SysMLPartsVisitor2;
 import de.monticore.lang.sysmlv2.SysMLv2Mill;
-import de.monticore.lang.sysmlv2._ast.ASTSysMLModel;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 
-public class SpecializationToSubsettingVisitor implements SysMLBasisVisitor2, SysMLPartsVisitor2 {
-
-  @Override
-  public void endVisit(ASTSysMLElement node) {
-    
-    if (node instanceof ASTSysMLType) {
-      return;
-    }
-
-    replaceWrongSpecializations(node);
-  }
+public class SpecializationToSubsettingVisitor implements SysMLPartsVisitor2 {
 
   @Override
   public void endVisit(ASTAttributeUsage node) {
+    List<ASTSpecialization> newList = new ArrayList<>();
+    boolean changed = false;
 
-    replaceWrongSpecializations(node);
+    for (ASTSpecialization specialization : node.getSpecializationList()) {
+      if (specialization instanceof ASTSysMLSpecialization) {
+        ASTSysMLSpecialization sysMLSpecialization =
+            (ASTSysMLSpecialization) specialization;
 
-  }
+        ASTSysMLSubsetting subsetting =
+            SysMLv2Mill.sysMLSubsettingBuilder()
+                .setSuperTypesList(new ArrayList<>(
+                    sysMLSpecialization.getSuperTypesList()))
+                .build();
 
-  @SuppressWarnings("unchecked")
-  protected void replaceWrongSpecializations(ASTSysMLElement node) {
-
-    try {
-
-      Method getter = node.getClass().getMethod("getSpecializationList");
-      Method setter = node.getClass().getMethod("setSpecializationList", List.class);
-
-      List<ASTSpecialization> oldList = (List<ASTSpecialization>) getter.invoke(node);
-
-      List<ASTSpecialization> newList = new ArrayList<>();
-      boolean changed = false;
-
-      for (ASTSpecialization specialization : oldList) {
-
-        if (specialization instanceof ASTSysMLSpecialization) {
-
-          ASTSysMLSpecialization sysMLSpecialization = (ASTSysMLSpecialization) specialization;
-          newList.add(createSubsetting(sysMLSpecialization));
-          changed = true;
-
-        } else {
-          newList.add(specialization);
+        if (sysMLSpecialization.isPresentSysMLCardinality()) {
+          subsetting.setSysMLCardinality(
+              sysMLSpecialization.getSysMLCardinality());
         }
+
+        subsetting.set_SourcePositionStart(
+            sysMLSpecialization.get_SourcePositionStart());
+        subsetting.set_SourcePositionEnd(
+            sysMLSpecialization.get_SourcePositionEnd());
+
+        newList.add(subsetting);
+        changed = true;
       }
-
-      if (changed) {
-        setter.invoke(node, newList);
+      else {
+        newList.add(specialization);
       }
     }
-    catch (NoSuchMethodException ignored) {
-      // Some SysML elements do not have a specializationList.
+
+    if (changed) {
+      node.setSpecializationList(newList);
     }
-    catch (IllegalAccessException | InvocationTargetException e) {
-
-      throw new IllegalStateException("Could not rewrite specialization list of " + node.getClass().getSimpleName(), e);
-
-    }
-  }
-
-  protected ASTSysMLSubsetting createSubsetting(ASTSysMLSpecialization specialization) {
-    ASTSysMLSubsetting subsetting = SysMLv2Mill.sysMLSubsettingBuilder().setSuperTypesList(new ArrayList<>(specialization.getSuperTypesList())).build();
-
-    if (specialization.isPresentSysMLCardinality()) {
-
-      subsetting.setSysMLCardinality(specialization.getSysMLCardinality());
-
-    }
-
-    subsetting.set_SourcePositionStart(specialization.get_SourcePositionStart());
-    subsetting.set_SourcePositionEnd(specialization.get_SourcePositionEnd());
-    return subsetting;
-  }
-
-  public static void apply(ASTSysMLModel ast) {
-
-    SpecializationToSubsettingVisitor visitor = new SpecializationToSubsettingVisitor();
-    var traverser = SysMLv2Mill.traverser();
-    traverser.add4SysMLBasis(visitor);
-    traverser.add4SysMLParts(visitor);
-    ast.accept(traverser);
-
   }
 }

--- a/language/src/main/java/de/monticore/lang/sysmlv2/visitors/SpecializationToSubsettingVisitor.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/visitors/SpecializationToSubsettingVisitor.java
@@ -1,0 +1,101 @@
+package de.monticore.lang.sysmlv2.visitors;
+
+import de.monticore.lang.sysmlbasis._ast.ASTSpecialization;
+import de.monticore.lang.sysmlbasis._ast.ASTSysMLElement;
+import de.monticore.lang.sysmlbasis._ast.ASTSysMLSpecialization;
+import de.monticore.lang.sysmlbasis._ast.ASTSysMLSubsetting;
+import de.monticore.lang.sysmlbasis._ast.ASTSysMLType;
+import de.monticore.lang.sysmlbasis._visitor.SysMLBasisVisitor2;
+import de.monticore.lang.sysmlparts._ast.ASTAttributeUsage;
+import de.monticore.lang.sysmlparts._visitor.SysMLPartsVisitor2;
+import de.monticore.lang.sysmlv2.SysMLv2Mill;
+import de.monticore.lang.sysmlv2._ast.ASTSysMLModel;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+public class SpecializationToSubsettingVisitor implements SysMLBasisVisitor2, SysMLPartsVisitor2 {
+
+  @Override
+  public void endVisit(ASTSysMLElement node) {
+    
+    if (node instanceof ASTSysMLType) {
+      return;
+    }
+
+    replaceWrongSpecializations(node);
+  }
+
+  @Override
+  public void endVisit(ASTAttributeUsage node) {
+
+    replaceWrongSpecializations(node);
+
+  }
+
+  @SuppressWarnings("unchecked")
+  protected void replaceWrongSpecializations(ASTSysMLElement node) {
+
+    try {
+
+      Method getter = node.getClass().getMethod("getSpecializationList");
+      Method setter = node.getClass().getMethod("setSpecializationList", List.class);
+
+      List<ASTSpecialization> oldList = (List<ASTSpecialization>) getter.invoke(node);
+
+      List<ASTSpecialization> newList = new ArrayList<>();
+      boolean changed = false;
+
+      for (ASTSpecialization specialization : oldList) {
+
+        if (specialization instanceof ASTSysMLSpecialization) {
+
+          ASTSysMLSpecialization sysMLSpecialization = (ASTSysMLSpecialization) specialization;
+          newList.add(createSubsetting(sysMLSpecialization));
+          changed = true;
+
+        } else {
+          newList.add(specialization);
+        }
+      }
+
+      if (changed) {
+        setter.invoke(node, newList);
+      }
+    }
+    catch (NoSuchMethodException ignored) {
+      // Some SysML elements do not have a specializationList.
+    }
+    catch (IllegalAccessException | InvocationTargetException e) {
+
+      throw new IllegalStateException("Could not rewrite specialization list of " + node.getClass().getSimpleName(), e);
+
+    }
+  }
+
+  protected ASTSysMLSubsetting createSubsetting(ASTSysMLSpecialization specialization) {
+    ASTSysMLSubsetting subsetting = SysMLv2Mill.sysMLSubsettingBuilder().setSuperTypesList(new ArrayList<>(specialization.getSuperTypesList())).build();
+
+    if (specialization.isPresentSysMLCardinality()) {
+
+      subsetting.setSysMLCardinality(specialization.getSysMLCardinality());
+
+    }
+
+    subsetting.set_SourcePositionStart(specialization.get_SourcePositionStart());
+    subsetting.set_SourcePositionEnd(specialization.get_SourcePositionEnd());
+    return subsetting;
+  }
+
+  public static void apply(ASTSysMLModel ast) {
+
+    SpecializationToSubsettingVisitor visitor = new SpecializationToSubsettingVisitor();
+    var traverser = SysMLv2Mill.traverser();
+    traverser.add4SysMLBasis(visitor);
+    traverser.add4SysMLParts(visitor);
+    ast.accept(traverser);
+
+  }
+}

--- a/language/src/test/java/astrules/SpecializationToSubsettingVisitorTest.java
+++ b/language/src/test/java/astrules/SpecializationToSubsettingVisitorTest.java
@@ -1,0 +1,89 @@
+/* (c) https://github.com/MontiCore/monticore */
+package astrules;
+
+import de.monticore.lang.sysmlbasis._ast.ASTSpecialization;
+import de.monticore.lang.sysmlbasis._ast.ASTSysMLSpecialization;
+import de.monticore.lang.sysmlbasis._ast.ASTSysMLSubsetting;
+import de.monticore.lang.sysmlbasis._ast.ASTSysMLTyping;
+import de.monticore.lang.sysmlparts._ast.ASTAttributeDef;
+import de.monticore.lang.sysmlparts._ast.ASTAttributeUsage;
+import de.monticore.lang.sysmlv2.SysMLv2Mill;
+import de.monticore.lang.sysmlv2._ast.ASTSysMLModel;
+import de.monticore.lang.sysmlv2.visitors.SpecializationToSubsettingVisitor;
+import de.se_rwth.commons.logging.LogStub;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SpecializationToSubsettingVisitorTest {
+
+  @BeforeAll
+  public static void init() {
+    LogStub.init();
+    SysMLv2Mill.init();
+  }
+
+  @Test
+  public void shouldKeepRealSpecializationOfDefinition() throws IOException {
+    Optional<ASTSysMLModel> ast = SysMLv2Mill.parser().parse_String(
+        "attribute def Lebewesen; "
+            + "attribute def Person :> Lebewesen;"
+    );
+
+    assertThat(ast).isPresent();
+
+    ASTAttributeDef person = (ASTAttributeDef) ast.get().getSysMLElement(1);
+
+    assertThat(person.getSpecializationList()).hasSize(1);
+    assertThat(person.getSpecialization(0)).isInstanceOf(ASTSysMLSpecialization.class);
+    assertThat(person.getSpecialization(0)).isNotInstanceOf(ASTSysMLSubsetting.class);
+
+    SpecializationToSubsettingVisitor.apply(ast.get());
+
+    assertThat(person.getSpecializationList()).hasSize(1);
+    assertThat(person.getSpecialization(0)).isInstanceOf(ASTSysMLSpecialization.class);
+    assertThat(person.getSpecialization(0)).isNotInstanceOf(ASTSysMLSubsetting.class);
+  }
+
+  @Test
+  public void shouldRewriteWrongSpecializationOfUsageToSubsetting() throws IOException {
+    Optional<ASTSysMLModel> ast = SysMLv2Mill.parser().parse_String(
+        "attribute def Person; "
+            + "attribute alleMenschenDieserErde; "
+            + "attribute p : Person :> alleMenschenDieserErde;"
+    );
+
+    assertThat(ast).isPresent();
+
+    ASTAttributeUsage p = (ASTAttributeUsage) ast.get().getSysMLElement(2);
+
+    List<ASTSpecialization> before = p.getSpecializationList();
+
+    // Parser-Verhalten ohne Visitor:
+    // ": Person" ist korrekt ein Typing.
+    // ":> alleMenschenDieserErde" wird wegen der Grammatik zunächst falsch als Specialization geparst.
+    assertThat(before).hasSize(2);
+    assertThat(before.get(0)).isInstanceOf(ASTSysMLTyping.class);
+    assertThat(before.get(1)).isInstanceOf(ASTSysMLSpecialization.class);
+    assertThat(before.get(1)).isNotInstanceOf(ASTSysMLSubsetting.class);
+
+    SpecializationToSubsettingVisitor.apply(ast.get());
+
+    List<ASTSpecialization> after = p.getSpecializationList();
+
+    // Nach dem Visitor:
+    // Typing bleibt erhalten.
+    // Die falsche Specialization ist weg.
+    // Stattdessen gibt es genau ein Subsetting.
+    assertThat(after).hasSize(2);
+    assertThat(after.get(0)).isInstanceOf(ASTSysMLTyping.class);
+    assertThat(after.get(1)).isInstanceOf(ASTSysMLSubsetting.class);
+    assertThat(after.get(1)).isNotInstanceOf(ASTSysMLSpecialization.class);
+  }
+
+}

--- a/language/src/test/java/astrules/SpecializationToSubsettingVisitorTest.java
+++ b/language/src/test/java/astrules/SpecializationToSubsettingVisitorTest.java
@@ -43,7 +43,11 @@ public class SpecializationToSubsettingVisitorTest {
     assertThat(person.getSpecialization(0)).isInstanceOf(ASTSysMLSpecialization.class);
     assertThat(person.getSpecialization(0)).isNotInstanceOf(ASTSysMLSubsetting.class);
 
-    SpecializationToSubsettingVisitor.apply(ast.get());
+    SpecializationToSubsettingVisitor visitor =
+        new SpecializationToSubsettingVisitor();
+    var traverser = SysMLv2Mill.traverser();
+    traverser.add4SysMLParts(visitor);
+    ast.get().accept(traverser);
 
     assertThat(person.getSpecializationList()).hasSize(1);
     assertThat(person.getSpecialization(0)).isInstanceOf(ASTSysMLSpecialization.class);
@@ -72,7 +76,11 @@ public class SpecializationToSubsettingVisitorTest {
     assertThat(before.get(1)).isInstanceOf(ASTSysMLSpecialization.class);
     assertThat(before.get(1)).isNotInstanceOf(ASTSysMLSubsetting.class);
 
-    SpecializationToSubsettingVisitor.apply(ast.get());
+    SpecializationToSubsettingVisitor visitor =
+        new SpecializationToSubsettingVisitor();
+    var traverser = SysMLv2Mill.traverser();
+    traverser.add4SysMLParts(visitor);
+    ast.get().accept(traverser);
 
     List<ASTSpecialization> after = p.getSpecializationList();
 


### PR DESCRIPTION
Ein Visitor wurde hinzugefügt, der alle Vorkommen von SysMLSpecialization prüft und ggfs. auf SysMLSubsetting umbaut, falls dieser durch die identische Abkürzung (:>) falsch interpretiert wurde.
Es wurde auch ein Test hinzugefügt, der einmal Testet, ob eine korrekte Specialization unverändert bleibet und einmal ob ein eigentliches Subsetting korrekt umgeformt wird.