### PR TITLE
replace usage of resolvepartdef  with resolvetype in PartTypeDefinitionExistsCoCo 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,4 +25,4 @@ assertj_version    = 3.21.0
 junit_version      = 5.8.2
 
 # Version of published artifacts
-version            = 7.8.65
+version            = 7.8.66

--- a/language/src/main/java/de/monticore/lang/sysmlv2/cocos/PartTypeDefinitionExistsCoCo.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/cocos/PartTypeDefinitionExistsCoCo.java
@@ -5,6 +5,7 @@ import de.monticore.lang.sysmlbasis._ast.ASTSpecialization;
 import de.monticore.lang.sysmlbasis._ast.ASTSysMLTyping;
 import de.monticore.lang.sysmlparts._ast.ASTPartUsage;
 import de.monticore.lang.sysmlparts._cocos.SysMLPartsASTPartUsageCoCo;
+import de.monticore.lang.sysmlparts.symboltable.adapters.PartDef2TypeSymbolAdapter;
 import de.monticore.types.mcbasictypes._ast.ASTMCType;
 import de.se_rwth.commons.logging.Log;
 
@@ -25,7 +26,10 @@ public class PartTypeDefinitionExistsCoCo implements SysMLPartsASTPartUsageCoCo 
         .filter(s -> s instanceof ASTSysMLTyping)
         .flatMap(ASTSpecialization::streamSuperTypes)
         .filter(t ->
-            node.getEnclosingScope().resolvePartDef(printPartType(t)).isEmpty()
+            node.getEnclosingScope()
+                .resolveType(printPartType(t))
+                .filter(PartDef2TypeSymbolAdapter.class::isInstance)
+                .isEmpty()
         )
         .collect(Collectors.toList());
 


### PR DESCRIPTION
## Fix

- Fixed resolution of PartDefs in `PartTypeDefinitionExistsCoCo `by replacing `resolvePartdef `with `resolveType`
- Check that the resolved type is a PartDef2TypeSymbolAdapter


