### PR TITLE
Remove refinement dependency check from CoCo

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,4 +25,4 @@ assertj_version    = 3.21.0
 junit_version      = 5.8.2
 
 # Version of published artifacts
-version            = 7.8.66
+version            = 7.8.67

--- a/language/src/main/java/de/monticore/lang/sysmlv2/cocos/RefinementTargetDefinitionExistsCoCo.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/cocos/RefinementTargetDefinitionExistsCoCo.java
@@ -26,17 +26,10 @@ public class RefinementTargetDefinitionExistsCoCo implements SysMLPartsASTPartDe
         .filter(s -> s instanceof ASTSysMLRefinement)
         .flatMap(ASTSpecialization::streamSuperTypes)
         .map((ASTMCType t) -> t.printType())
-        .filter(name -> node.getEnclosingScope().resolvePartDef(name).isEmpty());
-
-    var nonExistentDependencies = node.getRefinementDependencies().stream()
-        .flatMap(dep -> dep.getTargetsList().stream())
-        .map(Object::toString)
-        .filter(name -> node.getEnclosingScope().resolvePartDef(name).isEmpty());
-
-    var nonExistent = Stream.concat(nonExistentSpecializations, nonExistentDependencies)
+        .filter(name -> node.getEnclosingScope().resolvePartDef(name).isEmpty())
         .collect(Collectors.toList());
 
-    for (var problem : nonExistent) {
+    for (var problem : nonExistentSpecializations) {
       Log.error(
           "0x10AA2 The name used in 'refines' \"" + problem
               + "\" does not exist as a part definition.",

--- a/language/src/test/java/cocos/RefinementTargetDefinitionExistsCoCoTest.java
+++ b/language/src/test/java/cocos/RefinementTargetDefinitionExistsCoCoTest.java
@@ -72,6 +72,7 @@ public class RefinementTargetDefinitionExistsCoCoTest {
       assertThat(errors).hasSize(0);
     }
 
+    @Disabled("Currently the refinement dependency targets are not checked")
     @Test
     public void testInvalidDependencyTarget() throws IOException {
       String invalidModel =


### PR DESCRIPTION
## Changed

- Disabled the invalid refinement dependency target test because we don't check it

## Removed 

- Remove refinement dependency target check 