### PR TITLE
7.8.68: Kompatibilitaet von ScalarValues Boolean mit MC primitive boolean 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,4 +25,4 @@ assertj_version    = 3.21.0
 junit_version      = 5.8.2
 
 # Version of published artifacts
-version            = 7.8.67
+version            = 7.8.68

--- a/language/src/main/java/de/monticore/lang/sysmlv2/cocos/ConstraintIsBooleanTC3.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/cocos/ConstraintIsBooleanTC3.java
@@ -5,6 +5,7 @@ import de.monticore.expressions.expressionsbasis._ast.ASTExpression;
 import de.monticore.lang.sysmlconstraints._ast.ASTConstraintUsage;
 import de.monticore.lang.sysmlconstraints._cocos.SysMLConstraintsASTConstraintUsageCoCo;
 import de.monticore.types.check.SymTypeExpression;
+import de.monticore.types3.SymTypeRelations;
 import de.monticore.types3.TypeCheck3;
 import de.se_rwth.commons.SourcePosition;
 import de.se_rwth.commons.SourcePositionBuilder;
@@ -23,7 +24,7 @@ public class ConstraintIsBooleanTC3 implements SysMLConstraintsASTConstraintUsag
         var end = constraintEnd(start);
         Log.error("0x80001 Failed to derive a type!", start, end);
       }
-      else if(!type.printFullName().equals("boolean")) {
+      else if(!SymTypeRelations.isBoolean(type)) {
         Log.error("0x80002 The expression type is '" + type.printFullName() + "' but should be boolean!", expr.get_SourcePositionStart(), expr.get_SourcePositionEnd());
       }
     }

--- a/language/src/main/java/de/monticore/lang/sysmlv2/cocos/TypeCheck3TransitionGuards.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/cocos/TypeCheck3TransitionGuards.java
@@ -4,6 +4,7 @@ import de.monticore.expressions.expressionsbasis._ast.ASTExpression;
 import de.monticore.lang.sysmlstates._ast.ASTSysMLTransition;
 import de.monticore.lang.sysmlstates._cocos.SysMLStatesASTSysMLTransitionCoCo;
 import de.monticore.types.check.SymTypeExpression;
+import de.monticore.types3.SymTypeRelations;
 import de.monticore.types3.TypeCheck3;
 import de.se_rwth.commons.logging.Log;
 
@@ -22,7 +23,7 @@ public class TypeCheck3TransitionGuards implements SysMLStatesASTSysMLTransition
               expr.get_SourcePositionStart(),
               expr.get_SourcePositionEnd());
         }
-        else if(!type.isPrimitive() || !type.asPrimitive().getPrimitiveName().equals("boolean")) {
+        else if(!SymTypeRelations.isBoolean(type)) {
           Log.error("0x80005 The expression type is '" + type.printFullName() + "' but should be boolean!",
               expr.get_SourcePositionStart(),
               expr.get_SourcePositionEnd());

--- a/language/src/main/java/de/monticore/lang/sysmlv2/types3/SysMLOCLExpressionsTypeVisitor.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/types3/SysMLOCLExpressionsTypeVisitor.java
@@ -73,8 +73,7 @@ public class SysMLOCLExpressionsTypeVisitor extends OCLExpressionsTypeVisitor im
       SymTypeExpression left, SymTypeExpression right) {
 
     if (SymTypeRelations.isCompatible(left, right)
-        && left.isPrimitive()
-        && left.asPrimitive().getPrimitiveName().equals("boolean")) {
+        && SymTypeRelations.isBoolean(left)) {
       return SymTypeExpressionFactory.createPrimitive(BasicSymbolsMill.BOOLEAN);
     }
     return SymTypeExpressionFactory.createObscureType();

--- a/language/src/main/java/de/monticore/lang/sysmlv2/types3/SysMLSymTypeRelations.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/types3/SysMLSymTypeRelations.java
@@ -3,6 +3,7 @@ package de.monticore.lang.sysmlv2.types3;
 import de.monticore.ocl.types3.OCLSymTypeRelations;
 import de.monticore.types.check.SymTypeExpression;
 import de.monticore.types3.util.BuiltInTypeRelations;
+import de.monticore.types3.util.SymTypeCompatibilityCalculator;
 import de.monticore.types3.util.SymTypeRelationsDefaultDelegatee;
 
 public abstract class SysMLSymTypeRelations extends OCLSymTypeRelations {
@@ -21,6 +22,34 @@ public abstract class SysMLSymTypeRelations extends OCLSymTypeRelations {
           return super.isIntegralType(type) ||
               type.isPrimitive() &&
                   type.asPrimitive().getPrimitiveName().equals("nat");
+        }
+
+        /*
+        Any Type that is included here will be compatible with any other Type
+        in the list.
+         */
+        @Override
+        public boolean isBoolean(SymTypeExpression type) {
+          return (super.isBoolean(type) ||
+            (
+              type.hasTypeInfo() &&
+              type.getTypeInfo().getFullName().equals("ScalarValues.Boolean")
+            )
+          );
+        }
+      };
+
+      compatibilityDelegate = new SymTypeCompatibilityCalculator() {
+        @Override
+        public boolean isCompatible(
+            SymTypeExpression target,
+            SymTypeExpression source) {
+          return (super.isCompatible(target, source) ||
+            (
+              builtInRelationsDelegate.isBoolean(target) &&
+              builtInRelationsDelegate.isBoolean(source)
+            )
+          );
         }
       };
     }


### PR DESCRIPTION
## Changed

- ScalarValues::Booleans sind nun auch mit internen MC primitive booleans kompatibel