### PR TITLE
Added: interface SysMLUsage

### DIFF
--- a/language/src/main/grammars/de/monticore/lang/SysMLActions.mc4
+++ b/language/src/main/grammars/de/monticore/lang/SysMLActions.mc4
@@ -225,7 +225,7 @@ component grammar SysMLActions
       Expression?
     "}" | ";") ;
 
-  symbol scope CalcUsage implements SysMLElement =
+  symbol scope CalcUsage implements SysMLUsage =
     Modifier UserDefinedKeyword* "calc" SysMLIdentifier? Name? SysMLCardinality? Specialization*
     DefaultValue?
     ("{"

--- a/language/src/main/grammars/de/monticore/lang/SysMLBasis.mc4
+++ b/language/src/main/grammars/de/monticore/lang/SysMLBasis.mc4
@@ -60,6 +60,9 @@ component grammar SysMLBasis
    */
   interface Specialization = superTypes:MCType+;
 
+  // Interface zum Unterscheiden zwischen Usages und anderen Typen mit dem Visitor
+  interface SysMLUsage extends SysMLElement = Specialization*;
+
   // Specialization ist spezifisch für Definitions
   SysMLSpecialization implements Specialization =
       (":>" | "specializes") superTypes:(MCType || ",")+ SysMLCardinality?;
@@ -250,7 +253,7 @@ component grammar SysMLBasis
    * Anonyme Usage, deren "Typ" im Sinne der SysML (also Beispielsweise "attribute" oder "part") sich erst durch
    * die Spezialisationen (Typisierungen) ergibt.
    */
-  symbol scope AnonymousUsage implements SysMLElement =
+  symbol scope AnonymousUsage implements SysMLUsage =
       Modifier UserDefinedKeyword* SysMLIdentifier? Name? SysMLCardinality?
       Specialization+ DefaultValue?
       ("{"
@@ -262,7 +265,7 @@ component grammar SysMLBasis
       in:boolean
       out:boolean ;
 
-  symbol scope AnonymousReference implements SysMLElement =
+  symbol scope AnonymousReference implements SysMLUsage =
        Modifier UserDefinedKeyword* SysMLIdentifier? src:MCQualifiedName SysMLCardinality?
        Specialization* DefaultValue?
        ("{"
@@ -278,7 +281,7 @@ component grammar SysMLBasis
    * Occurrence usages can be used in successions.
    * Example: "first send a to b if b then perform myAction;"
    */
-  interface OccurrenceUsageElement extends SysMLElement;
+  interface OccurrenceUsageElement extends SysMLUsage;
 
   // Inline-Variante für das "first" vor dem "then"
   interface IInlineOccurrenceUsage ;

--- a/language/src/main/grammars/de/monticore/lang/SysMLConstraints.mc4
+++ b/language/src/main/grammars/de/monticore/lang/SysMLConstraints.mc4
@@ -13,7 +13,7 @@ component grammar SysMLConstraints
       Expression?
     "}" | ";") ;
 
-  symbol scope ConstraintUsage implements SysMLElement =
+  symbol scope ConstraintUsage implements SysMLUsage =
     Modifier (
       (["require"] | ["assume"] | ["assert"]) ["not"]? UserDefinedKeyword* "constraint"?
       | UserDefinedKeyword* "constraint"
@@ -24,7 +24,7 @@ component grammar SysMLConstraints
       Expression?
     "}" | ";") ;
 
-  ConstraintReference implements SysMLElement =
+  ConstraintReference implements SysMLUsage =
     (
       (["require"] | ["assume"] | ["assert"]) UserDefinedKeyword* "constraint"?
       | UserDefinedKeyword* "constraint"
@@ -46,7 +46,7 @@ component grammar SysMLConstraints
 
   // Satisfy Requirement Usages are ConstraintUsages and as such can be
   // required/assumed/asserted
-  symbol scope RequirementUsage implements SysMLElement =
+  symbol scope RequirementUsage implements SysMLUsage =
       Modifier (["require"] | ["assume"] | ["assert"])? UserDefinedKeyword*
       ["verify"]? ["not"]? ["satisfy"]? "requirement"
       SysMLIdentifier? Name? SysMLCardinality? Specialization*
@@ -101,7 +101,7 @@ component grammar SysMLConstraints
    * rather than verify requirement to declare a verified requirement using
    * reference subsetting.
    */
-  RequirementVerification implements SysMLElement =
+  RequirementVerification implements SysMLUsage =
       "verify" req:MCQualifiedName SysMLCardinality? Specialization*
       ("{"
           SysMLElement*
@@ -115,7 +115,7 @@ component grammar SysMLConstraints
         SysMLElement*
       "}" | ";") ;
 
-  symbol scope ConcernUsage implements SysMLElement =
+  symbol scope ConcernUsage implements SysMLUsage =
       Modifier UserDefinedKeyword* ["frame"]? "concern"
       SysMLIdentifier? Name? SysMLCardinality? Specialization*
       ("(" (SysMLParameter || ",")* ")")?

--- a/language/src/main/grammars/de/monticore/lang/SysMLParts.mc4
+++ b/language/src/main/grammars/de/monticore/lang/SysMLParts.mc4
@@ -43,7 +43,7 @@ component grammar SysMLParts extends SysMLBasis {
       (SysMLElement | AnonEnumUsage)*
     "}" | ";") ;
 
-  symbol EnumUsage implements SysMLElement =
+  symbol EnumUsage implements SysMLUsage =
     Modifier UserDefinedKeyword* "enum"
     SysMLIdentifier? Name? SysMLCardinality? Specialization* DefaultValue?
     ("{"
@@ -72,7 +72,7 @@ component grammar SysMLParts extends SysMLBasis {
    * ##################################################################
    */
 
-  symbol scope PartUsage implements SysMLElement =
+  symbol scope PartUsage implements SysMLUsage =
     Modifier UserDefinedKeyword* "part" SysMLIdentifier? Name?
     SysMLCardinality? Specialization* DefaultValue?
     ("{"
@@ -102,7 +102,7 @@ component grammar SysMLParts extends SysMLBasis {
         return Optional.empty();
       } ;
 
-  symbol scope AttributeUsage implements SysMLElement =
+  symbol scope AttributeUsage implements SysMLUsage =
       Modifier UserDefinedKeyword* "attribute"
       SysMLIdentifier? Name? SysMLCardinality?
       Specialization* DefaultValue?
@@ -137,7 +137,7 @@ component grammar SysMLParts extends SysMLBasis {
    * integrate with the existing artifacts (i.e., theories containing specific channel names) only by referencing the
    * symboltable (and not needing to re-processes the original models).
    */
-  symbol scope PortUsage implements SysMLElement =
+  symbol scope PortUsage implements SysMLUsage =
       Modifier UserDefinedKeyword* "port"
       SysMLIdentifier? Name? SysMLCardinality? Specialization* DefaultValue?
       ("{"
@@ -166,7 +166,7 @@ component grammar SysMLParts extends SysMLBasis {
    * CONNECTIONS
    * ##################################################################
    */
-  symbol ConnectionUsage implements SysMLElement =
+  symbol ConnectionUsage implements SysMLUsage =
     Modifier UserDefinedKeyword* "connection"?
     SysMLIdentifier? Name? SysMLCardinality? Specialization*
     "connect" (
@@ -186,7 +186,7 @@ component grammar SysMLParts extends SysMLBasis {
   FlowPayload =
     (Name SysMLCardinality? Specialization* | MCType SysMLCardinality?) DefaultValue? ;
 
-  FlowUsage implements SysMLElement =
+  FlowUsage implements SysMLUsage =
     Modifier UserDefinedKeyword* "succession"? "flow"
     SysMLIdentifier? Name? SysMLCardinality? Specialization*
     ("of" FlowPayload)?
@@ -197,7 +197,7 @@ component grammar SysMLParts extends SysMLBasis {
       "}" | ";") ;
 
   // explizites bind durch keyword
-  Bind implements SysMLElement =
+  Bind implements SysMLUsage =
     Modifier UserDefinedKeyword* "binding"?
     SysMLIdentifier? Name? SysMLCardinality? Specialization*
     "bind" source:Endpoint "=" target:Endpoint
@@ -224,7 +224,7 @@ component grammar SysMLParts extends SysMLBasis {
 
   // Aus Kompatibilitätsgründen ist der Name hier nicht "ConnectionUsage". Genau genommen ist ein einfaches
   // "connect" der Sonderfall, nicht andersrum.
-  symbol scope ConnectionUsageProper implements SysMLElement =
+  symbol scope ConnectionUsageProper implements SysMLUsage =
     Modifier UserDefinedKeyword* "connection"
     SysMLIdentifier? Name? SysMLCardinality? Specialization*
     ("{"
@@ -245,7 +245,7 @@ component grammar SysMLParts extends SysMLBasis {
       SysMLElement*
     "}" | ";") ;
 
-  symbol scope InterfaceUsage implements SysMLElement =
+  symbol scope InterfaceUsage implements SysMLUsage =
     Modifier UserDefinedKeyword* "interface"
     SysMLIdentifier? Name? SysMLCardinality? Specialization*
     ("connect"? (
@@ -275,7 +275,7 @@ component grammar SysMLParts extends SysMLBasis {
       SysMLElement*
     "}" | ";") ;
 
-  symbol scope AllocationUsage implements SysMLElement =
+  symbol scope AllocationUsage implements SysMLUsage =
     Modifier UserDefinedKeyword* "allocation"
     SysMLIdentifier? Name? SysMLCardinality? Specialization*
     ("{"
@@ -347,7 +347,7 @@ component grammar SysMLParts extends SysMLBasis {
       SysMLElement*
     "}" | ";") ;
 
-  symbol scope ItemUsage implements SysMLElement =
+  symbol scope ItemUsage implements SysMLUsage =
     Modifier UserDefinedKeyword* "item" SysMLIdentifier? Name? SysMLCardinality? Specialization*
     ("(" (SysMLParameter || ",")* ")")? DefaultValue?
     ("{"
@@ -390,7 +390,7 @@ component grammar SysMLParts extends SysMLBasis {
         (AnalysisObjective | SysMLElement)*
       "}" | ";") ;
 
-  symbol scope AnalysisUsage implements SysMLElement =
+  symbol scope AnalysisUsage implements SysMLUsage =
       Modifier UserDefinedKeyword* "analysis"
       SysMLIdentifier? Name? SysMLCardinality? Specialization*
       ("{"
@@ -406,7 +406,7 @@ component grammar SysMLParts extends SysMLBasis {
         Expression?
       "}" | ";") ;
 
-  symbol scope VerificationUsage implements SysMLElement =
+  symbol scope VerificationUsage implements SysMLUsage =
       Modifier UserDefinedKeyword* "verification"
       Name? SysMLCardinality? Specialization*
       ("{"
@@ -459,7 +459,7 @@ component grammar SysMLParts extends SysMLBasis {
         Expression?
       "}" | ";") ;
 
-  symbol scope CaseUsage implements SysMLElement =
+  symbol scope CaseUsage implements SysMLUsage =
       Modifier UserDefinedKeyword* "case"
       SysMLIdentifier? Name? SysMLCardinality? Specialization*
       ("{"
@@ -519,7 +519,7 @@ component grammar SysMLParts extends SysMLBasis {
         SysMLElement*
      "}" | ";") ;
 
-  SysMLMetaDataUsage implements SysMLElement =
+  SysMLMetaDataUsage implements SysMLUsage =
     Modifier UserDefinedKeyword* ("metadata" | "@")
     SysMLIdentifier? Name? SysMLCardinality? Specialization*
     ("about" about:(MCQualifiedName || ",")+)?
@@ -543,7 +543,7 @@ component grammar SysMLParts extends SysMLBasis {
         SysMLElement*
       "}" | ";") ;
 
-    symbol scope ViewpointUsage implements SysMLElement =
+    symbol scope ViewpointUsage implements SysMLUsage =
       Modifier UserDefinedKeyword* "viewpoint"
       SysMLIdentifier? Name? SysMLCardinality? Specialization*
       ("{"
@@ -561,7 +561,7 @@ component grammar SysMLParts extends SysMLBasis {
           (RenderingReference | SysMLElement)*
        "}" | ";") ;
 
-    symbol scope ViewUsage implements SysMLElement =
+    symbol scope ViewUsage implements SysMLUsage =
       Modifier UserDefinedKeyword* "view"
       SysMLIdentifier? Name? SysMLCardinality? Specialization*
       ("{"
@@ -593,7 +593,7 @@ component grammar SysMLParts extends SysMLBasis {
         SysMLElement*
       "}" | ";") ;
 
-    symbol scope RenderingUsage implements SysMLElement =
+    symbol scope RenderingUsage implements SysMLUsage =
       Modifier UserDefinedKeyword* ["render"]? "rendering"
       SysMLIdentifier? Name? SysMLCardinality? Specialization* DefaultValue?
       ("{"

--- a/language/src/main/grammars/de/monticore/lang/SysMLStates.mc4
+++ b/language/src/main/grammars/de/monticore/lang/SysMLStates.mc4
@@ -10,7 +10,7 @@ component grammar SysMLStates extends SysMLActions {
       (EntryAction | DoAction | ExitAction | SysMLElement)*
     "}" | ";") ;
 
-  symbol scope StateUsage implements SysMLElement =
+  symbol scope StateUsage implements SysMLUsage =
     Modifier UserDefinedKeyword* exhibited:["exhibit"]? "state" SysMLIdentifier?
     Name? SysMLCardinality? Specialization*
     ("(" (SysMLParameter || ",")* ")")? paralled:["parallel"]? DefaultValue?
@@ -18,7 +18,7 @@ component grammar SysMLStates extends SysMLActions {
       (EntryAction | DoAction | ExitAction | SysMLElement)*
     "}" | ";") ;
 
-  ExhibitedStateReference implements SysMLElement =
+  ExhibitedStateReference implements SysMLUsage =
     UserDefinedKeyword* "exhibit" MCQualifiedName?
     SysMLCardinality? Specialization*
     ("{"

--- a/language/src/main/grammars/de/monticore/lang/SysMLv2.mc4
+++ b/language/src/main/grammars/de/monticore/lang/SysMLv2.mc4
@@ -48,7 +48,7 @@ grammar SysMLv2 extends SysMLExpressions,
       SysMLElement*
     "}" | ";") ;
 
-  symbol scope UserDefinedUsage implements SysMLElement =
+  symbol scope UserDefinedUsage implements SysMLUsage =
     Modifier UserDefinedKeyword+ Name SysMLCardinality? Specialization*
     ("{"
       SysMLElement*


### PR DESCRIPTION
GitLab Ticket: [https://git.rwth-aachen.de/montibelle/frontend/transformer/sysmltransformer/-/work_items/359](https://git.rwth-aachen.de/montibelle/frontend/transformer/sysmltransformer/-/work_items/359)

In SysMLBasis.mc4 wurde ein neues Interface SysMLUsage hinzugefügt. Dieses ersetzt in den Grammatiken bei den ganzen Usages das interface SysMLElement, sodass man mit einem Visitor direkt generisch alle Usages visiten kann, ohne eine Fallunterscheidung für alle möglichen Fälle zu machen.