### PR TITLE
#326 Modified the KerML Grammar to be simpler

### DIFF
--- a/kerml/src/main/grammars/de/monticore/lang/KerMLExpressions.mc4
+++ b/kerml/src/main/grammars/de/monticore/lang/KerMLExpressions.mc4
@@ -6,6 +6,7 @@ component grammar KerMLExpressions
             de.monticore.expressions.CommonExpressions,
             de.monticore.literals.MCCommonLiterals
 {
+    // Same as Sysml
     ConditionalAndExpression implements Expression <120>, InfixExpression =
         left:Expression operator:"and" right:Expression;
 
@@ -21,29 +22,18 @@ component grammar KerMLExpressions
     ConditionalNotExpression implements Expression <190> =
         "not" Expression;
 
-    FeatureAssignment implements FeatureInit =
-        "=" Expression (FeatureBlock | ";");
+    KerMLEnumerationExpression implements Expression =
+        "(" start:Expression ".." end:Expression ")" ;
+    // Differs from Sysml but similar 
 
-    NullCoalescingExpression implements Expression =
-        Expression "??" Expression;
-
-    ArrowExpression implements Expression =
-        Expression "->" Expression;
-
-    KerMLLiteralArgExpression implements Expression =
-        Expression (Literal| EscapedName);
-
-    KerMLIteratorExpression implements Expression =
+    KerMLIteratorExpression implements Expression <120> =
         Expression "->" Name
         "{"
         ("in" iteratorName:Name ":" iteratorType:KerMLQualifiedName ";")?
         body:Expression
         "}";
 
-    KerMLIdentityExpression implements Expression =
-        Expression ("===" | "!==") Expression;
-
-    KerMLArrowExpression implements Expression =
+    KerMLFunctionOperationExpression implements Expression <120> =
         Expression "->" Name 
         ( 
             Arguments 
@@ -52,25 +42,39 @@ component grammar KerMLExpressions
           | EscapedName  
         )? ;
 
-    KerMLIndexExpression implements Expression =
+    KerMLIndexExpression implements Expression <130> =
         Expression "#" ( "(" Expression ")" | "(index)" );
 
-    KerMLQualifiedNameExpression implements Expression =
-        KerMLQualifiedName ;
+    // Not in Sysml
+    FeatureAssignment implements FeatureInit <110> =
+        "=" Expression (FeatureBlock | ";");
 
-    KerMLEnumerationExpression implements Expression =
-    "(" start:Expression ".." end:Expression ")" ;
+    NullCoalescingExpression implements Expression <110> =
+        Expression "??" Expression;
+
+    ArrowExpression implements Expression <100> =
+        Expression "->" Expression;
+
+    KerMLLiteralArgExpression implements Expression <140> =
+        Expression (Literal| EscapedName);
+
+    KerMLIdentityExpression implements Expression <90> =
+        Expression ("===" | "!==") Expression;
+
+    KerMLQualifiedNameExpression implements Expression =
+        KerMLQualifiedName;
     
     KerMLTupleExpression implements Expression =
-        "(" Expression ("," Expression)+ ")" ;
+        "(" Expression ("," Expression)+ ")";
 
-    token KerMLScientificNumber = ('0'..'9')+ ("e" | "E") ("+" | "-")? ('0'..'9')+ ;
+    token KerMLScientificToken = ('0'..'9')+ ("e" | "E") ("+" | "-")? ('0'..'9')+ ;
     
-    token KerMLDecimalNumber = ('0'..'9')+ "." ('0'..'9')+ ( ("e" | "E") ("+" | "-")? ('0'..'9')+ )? ;
+    token KerMLDecimalToken = ('0'..'9')+ "." ('0'..'9')+ ( ("e" | "E") ("+" | "-")? ('0'..'9')+ )? ;
 
-    KerMLCustomNumericExpression implements Expression =
-        KerMLScientificNumber | KerMLDecimalNumber ;
+    KerMLScientificLiteral implements Literal = KerMLScientificToken;
+
+    KerMLDecimalNumber implements Literal = KerMLDecimalToken;
 
     KerMLIfElseExpression implements Expression =
-        "if" Expression "?" Expression "else" Expression ;
+        "if" Expression "?" Expression "else" Expression;
 }

--- a/kerml/src/main/grammars/de/monticore/lang/KerMLExpressions.mc4
+++ b/kerml/src/main/grammars/de/monticore/lang/KerMLExpressions.mc4
@@ -6,15 +6,29 @@ component grammar KerMLExpressions
             de.monticore.expressions.CommonExpressions,
             de.monticore.literals.MCCommonLiterals
 {
+    ConditionalAndExpression implements Expression <120>, InfixExpression =
+        left:Expression operator:"and" right:Expression;
+
+    ConditionalAndExpression2 implements Expression <120>, InfixExpression =
+        left:Expression operator:"&" right:Expression;
+
+    ConditionalOrExpression implements Expression <117>, InfixExpression =
+        left:Expression operator:"or" right:Expression;
+
+    ConditionalOrExpression2 implements Expression <117>, InfixExpression =
+        left:Expression operator:"|" right:Expression;
+
+    ConditionalNotExpression implements Expression <190> =
+        "not" Expression;
 
     FeatureAssignment implements FeatureInit =
         "=" Expression (FeatureBlock | ";");
 
     NullCoalescingExpression implements Expression =
-        Expression "??" Expression ;
+        Expression "??" Expression;
 
     ArrowExpression implements Expression =
-        Expression "->" Expression ;
+        Expression "->" Expression;
 
     KerMLLiteralArgExpression implements Expression =
         Expression (Literal| EscapedName);
@@ -25,12 +39,6 @@ component grammar KerMLExpressions
         ("in" iteratorName:Name ":" iteratorType:KerMLQualifiedName ";")?
         body:Expression
         "}";
-
-    KerMLNotExpression implements Expression =
-        "not" Expression ;
-
-    KerMLLogicalExpression implements Expression =
-        Expression ("and" | "or" | "&" | "|" | "implies" | "xor") Expression ;
 
     KerMLIdentityExpression implements Expression =
         Expression ("===" | "!==") Expression;
@@ -50,8 +58,8 @@ component grammar KerMLExpressions
     KerMLQualifiedNameExpression implements Expression =
         KerMLQualifiedName ;
 
-    KerMLRangeExpression implements Expression =
-        Expression ".." Expression ;
+    KerMLEnumerationExpression implements Expression =
+    "(" start:Expression ".." end:Expression ")" ;
     
     KerMLTupleExpression implements Expression =
         "(" Expression ("," Expression)+ ")" ;

--- a/kerml/src/main/grammars/de/monticore/lang/KerMLTypes.mc4
+++ b/kerml/src/main/grammars/de/monticore/lang/KerMLTypes.mc4
@@ -90,8 +90,8 @@ component grammar KerMLTypes
 
     FunctionCall = (QualifiedFunctionName? "(" (Expression ("," Expression)*)?")");
 
-    KerMLAsExpression implements Expression =
-        Expression "as" KerMLQualifiedName;
+    KerMLAsExpression implements Expression <150> =
+        left:Expression "as" right:KerMLQualifiedName;
 
     FunctionName = Name | EscapedName | SpecialName;
 


### PR DESCRIPTION
### Changes
- Took some SysMLExpressions and added them in the KerMLExpressions.
- Reordered the Expressions file and changed Scientific tokens to extend Literals instead of Expressions.