### PR TITLE
New Body Expression, Update FunctionOperation

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,4 +25,4 @@ assertj_version    = 3.21.0
 junit_version      = 5.8.2
 
 # Version of published artifacts
-version            = 7.8.69
+version            = 7.8.70

--- a/language/src/main/grammars/de/monticore/lang/SysMLExpressions.mc4
+++ b/language/src/main/grammars/de/monticore/lang/SysMLExpressions.mc4
@@ -114,8 +114,13 @@ component grammar SysMLExpressions
    * name of the function to be invoked and an argument list for any remaining arguments (see 7.4.9.4). This is
    * useful for chaining invocations in an effective data flow
    */
+   SysMLBodyExpression implements Expression =
+     "{" SysMLElement* inner:Expression "}" ;
+
   SysMLFunctionOperationExpression implements Expression <120> =
-    Expression "->" Name ("(" (SysMLParameter || ",")* ")")? ("{" SysMLElement* inner:Expression "}")? ;
+    Expression "->" Name
+    ("(" (SysMLParameter || ",")* ")")?
+    (body:SysMLBodyExpression)? ;
 
   // Eigentlich ist "^" der Name einer CalcDef aus den Domain Libraries
   CalcDefPowerExpression implements Expression =


### PR DESCRIPTION
Adds `SysMLBodyExpression` as a separate expression and updates `SysMLFunctionOperationExpression` to use the new body node.

The version was bumped to `7.8.70`.