### PR TITLE
Fix/function operation binding strength

### DIFF
--- a/language/src/main/grammars/de/monticore/lang/SysMLExpressions.mc4
+++ b/language/src/main/grammars/de/monticore/lang/SysMLExpressions.mc4
@@ -117,7 +117,7 @@ component grammar SysMLExpressions
    SysMLBodyExpression implements Expression =
      "{" SysMLElement* inner:Expression "}" ;
 
-  SysMLFunctionOperationExpression implements Expression <120> =
+  SysMLFunctionOperationExpression implements Expression <291> =
     Expression "->" Name
     ("(" (SysMLParameter || ",")* ")")?
     (body:SysMLBodyExpression)? ;

--- a/language/src/test/java/parser/ExpressionParserTest.java
+++ b/language/src/test/java/parser/ExpressionParserTest.java
@@ -12,6 +12,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import de.monticore.expressions.commonexpressions._ast.ASTFieldAccessExpression;
+import de.monticore.lang.sysmlexpressions._ast.ASTSysMLFunctionOperationExpression;
 
 import java.io.IOException;
 
@@ -80,6 +82,23 @@ public class ExpressionParserTest {
     assertThat(ast).isPresent();
     assertThat(Log.getFindings()).isEmpty();
     assertThat(ast.get()).isInstanceOf(ASTElementOfExpression.class);
+  }
+
+  /**
+   * Checks that a function operation following a field access binds correctly.
+   */
+  @Test
+  public void testFunctionOperationAfterFieldAccess() throws IOException {
+    var ast = parser.parse_StringExpression("a.b->c");
+
+    assertThat(ast).isPresent();
+    assertThat(Log.getFindings()).isEmpty();
+    assertThat(ast.get()).isInstanceOf(ASTSysMLFunctionOperationExpression.class);
+
+    var functionOperation = (ASTSysMLFunctionOperationExpression) ast.get();
+    assertThat(functionOperation.getExpression())
+        .isInstanceOf(ASTFieldAccessExpression.class);
+    assertThat(functionOperation.getName()).isEqualTo("c");
   }
 
 }


### PR DESCRIPTION
This MR adjusts the binding strength of function operation expressions to ensure that expressions such as a.b->c are parsed correctly. It also adds a parser test verifying the expected AST structure.