### PR TITLE
Support qualified names in function operations

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,4 +25,4 @@ assertj_version    = 3.21.0
 junit_version      = 5.8.2
 
 # Version of published artifacts
-version            = 7.8.78
+version            = 7.8.79

--- a/language/src/main/grammars/de/monticore/lang/SysMLExpressions.mc4
+++ b/language/src/main/grammars/de/monticore/lang/SysMLExpressions.mc4
@@ -118,7 +118,7 @@ component grammar SysMLExpressions
      "{" SysMLElement* inner:Expression "}" ;
 
   SysMLFunctionOperationExpression implements Expression <291> =
-    Expression "->" Name
+    Expression "->" SysMLQualifiedName
     ("(" (SysMLParameter || ",")* ")")?
     (body:SysMLBodyExpression)? ;
 

--- a/language/src/main/grammars/de/monticore/lang/SysMLExpressions.mc4
+++ b/language/src/main/grammars/de/monticore/lang/SysMLExpressions.mc4
@@ -118,7 +118,7 @@ component grammar SysMLExpressions
      "{" SysMLElement* inner:Expression "}" ;
 
   SysMLFunctionOperationExpression implements Expression <291> =
-    Expression "->" SysMLQualifiedName
+    Expression "->" MCQualifiedName
     ("(" (SysMLParameter || ",")* ")")?
     (body:SysMLBodyExpression)? ;
 

--- a/language/src/test/java/parser/ExpressionParserTest.java
+++ b/language/src/test/java/parser/ExpressionParserTest.java
@@ -98,7 +98,7 @@ public class ExpressionParserTest {
     var functionOperation = (ASTSysMLFunctionOperationExpression) ast.get();
     assertThat(functionOperation.getExpression())
         .isInstanceOf(ASTFieldAccessExpression.class);
-    assertThat(functionOperation.getSysMLQualifiedName().getPartsList()).containsExactly("c");
+    assertThat(functionOperation.getMCQualifiedName().getPartsList()).containsExactly("c");
   }
 
   /**
@@ -122,7 +122,7 @@ public class ExpressionParserTest {
     var functionOperation = (ASTSysMLFunctionOperationExpression) ast.get();
     assertThat(functionOperation.getExpression())
         .isInstanceOf(ASTFieldAccessExpression.class);
-    assertThat(functionOperation.getSysMLQualifiedName().getPartsList())
+    assertThat(functionOperation.getMCQualifiedName().getPartsList())
         .containsExactly("c", "d");
   }
 }

--- a/language/src/test/java/parser/ExpressionParserTest.java
+++ b/language/src/test/java/parser/ExpressionParserTest.java
@@ -98,7 +98,31 @@ public class ExpressionParserTest {
     var functionOperation = (ASTSysMLFunctionOperationExpression) ast.get();
     assertThat(functionOperation.getExpression())
         .isInstanceOf(ASTFieldAccessExpression.class);
-    assertThat(functionOperation.getName()).isEqualTo("c");
+    assertThat(functionOperation.getSysMLQualifiedName().getPartsList()).containsExactly("c");
   }
 
+  /**
+   * Checks that qualified names on both sides of a function operation
+   * are parsed with the correct binding.
+   */
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "a.b->c.d",
+      "a::b->c::d",
+      "a::b->c.d",
+      "a.b->c::d"
+  })
+  public void testQualifiedNamesInFunctionOperation(String expr) throws IOException {
+    var ast = parser.parse_StringExpression(expr);
+
+    assertThat(ast).isPresent();
+    assertThat(Log.getFindings()).isEmpty();
+    assertThat(ast.get()).isInstanceOf(ASTSysMLFunctionOperationExpression.class);
+
+    var functionOperation = (ASTSysMLFunctionOperationExpression) ast.get();
+    assertThat(functionOperation.getExpression())
+        .isInstanceOf(ASTFieldAccessExpression.class);
+    assertThat(functionOperation.getSysMLQualifiedName().getPartsList())
+        .containsExactly("c", "d");
+  }
 }


### PR DESCRIPTION
This PR adds support for qualified names in function operation expressions.

Function names following the -> operator can now be qualified using both . and ::. The parser tests cover all combinations of qualified names on both sides of the function operation:

a.b->c.d
a::b->c::d
a::b->c.d
a.b->c::d

The existing parser test was updated to use the generated SysMLQualifiedName AST node.