### PR TITLE
7.8.73: Entferne implizite Subject-Auflösung in Requirement-Constraints

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,4 +25,4 @@ assertj_version    = 3.21.0
 junit_version      = 5.8.2
 
 # Version of published artifacts
-version            = 7.8.72
+version            = 7.8.73

--- a/language/src/main/java/de/monticore/lang/sysmlv2/_symboltable/ISysMLv2Scope.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/_symboltable/ISysMLv2Scope.java
@@ -7,9 +7,7 @@ import de.monticore.lang.componentconnector._symboltable.MildComponentSymbol;
 import de.monticore.lang.componentconnector._symboltable.MildPortSymbol;
 import de.monticore.lang.componentconnector._symboltable.MildSpecificationSymbol;
 import de.monticore.lang.sysmlactions._symboltable.CalcUsageSymbol;
-import de.monticore.lang.sysmlbasis._ast.ASTSpecialization;
 import de.monticore.lang.sysmlbasis._symboltable.AnonymousUsageSymbol;
-import de.monticore.lang.sysmlconstraints._ast.ASTRequirementUsage;
 import de.monticore.lang.sysmlconstraints._symboltable.RequirementSubjectSymbol;
 import de.monticore.lang.sysmlconstraints.symboltable.adapters.RequirementSubject2VariableSymbolAdapter;
 import de.monticore.lang.sysmlparts._ast.ASTSysMLImportStatement;
@@ -45,10 +43,8 @@ import de.monticore.lang.sysmlv2.symboltable.adapters.StateUsage2AutomatonAdapte
 import de.monticore.lang.sysmlv2.symboltable.adapters.StateUsage2EventAutomatonAdapter;
 import de.monticore.lang.componentconnector._symboltable.RequirementSymbol;
 import de.monticore.symbols.basicsymbols._symboltable.FunctionSymbol;
-import de.monticore.symbols.basicsymbols._symboltable.IBasicSymbolsScope;
 import de.monticore.symbols.basicsymbols._symboltable.TypeSymbol;
 import de.monticore.symbols.basicsymbols._symboltable.VariableSymbol;
-import de.monticore.symboltable.IScopeSpanningSymbol;
 import de.monticore.symboltable.ImportStatement;
 import de.monticore.symboltable.modifiers.AccessModifier;
 import de.monticore.types.check.SymTypeExpression;
@@ -376,31 +372,6 @@ public interface ISysMLv2Scope extends ISysMLv2ScopeTOP {
     for (CalcUsageSymbol calcUsage : calcs) {
       var variable = new CalcUsage2VariableAdapter(calcUsage);
       adapted.add(variable);
-    }
-
-    // Falls Requirement, dann subject befragen
-    if (this.isPresentAstNode()
-        && this.getAstNode() instanceof ASTRequirementUsage) {
-      var ast = (ASTRequirementUsage) this.getAstNode();
-      if (ast.isPresentRequirementSubject()) {
-        // Alle Typen kommen in Frage
-        ast.getRequirementSubject().getSpecializationList().stream().flatMap(
-            ASTSpecialization::streamSuperTypes).forEach(t -> {
-          var typeSymbol = t.getDefiningSymbol();
-          if (typeSymbol.isPresent()
-              && typeSymbol.get() instanceof IScopeSpanningSymbol) {
-            var scope =
-                ((IScopeSpanningSymbol) typeSymbol.get()).getSpannedScope();
-            if (scope instanceof IBasicSymbolsScope) {
-              var variable = ((IBasicSymbolsScope) scope).resolveVariableDown(
-                  name, modifier, predicate);
-              if (variable.isPresent()) {
-                adapted.add(variable.get());
-              }
-            }
-          }
-        });
-      }
     }
 
     return adapted;

--- a/language/src/test/java/cocos/RequirementSubjectTest.java
+++ b/language/src/test/java/cocos/RequirementSubjectTest.java
@@ -22,17 +22,26 @@ public class RequirementSubjectTest extends NervigeSymboltableTests {
 
   @Test
   public void testValid() throws IOException {
-    var as = process("part def S { attribute a: boolean; } requirement R { subject s: S; constraint t { a } }");
+    var as = process("part def S { attribute a: boolean; } requirement R { subject s: S; constraint t { s.a } }");
     var errors = check((ASTSysMLModel) as.getAstNode());
     assertThat(errors).hasSize(0);
   }
 
   @Test
   public void testInvalid() throws IOException {
-    var as = process("part def S { attribute a: int; } requirement R { subject s: S; constraint t { a } }");
+    var as = process("part def S { attribute a: int; } requirement R { subject s: S; constraint t { s.a } }");
     var errors = check((ASTSysMLModel) as.getAstNode());
     assertThat(errors).hasSize(1);
     assertThat(errors.get(0).getMsg()).contains("should be boolean");
+  }
+
+  @Test
+  public void testInvalidImplizit() throws IOException {
+    var as = process("part def S { attribute a: boolean; } requirement R { subject s: S; constraint t { a } }");
+    var errors = check((ASTSysMLModel) as.getAstNode());
+    assertThat(errors).hasSize(2);
+    assertThat(errors.get(0).getMsg()).contains("0xFD118 could not find symbol");
+    assertThat(errors.get(1).getMsg()).contains("0x80001 Failed to derive a type");
   }
 
   private List<Finding> check(ASTSysMLModel ast) {


### PR DESCRIPTION
## Changed

- Die implizite Subject-Auflösung in Requirement-Constraints wurde entfernt

````
part def MySubject {
  port input : boolean;
}

requirement req_has_attr_input {
  subject target : MySubject;
  attribute input : boolean;

  assume constraint someBoolExpression {
    input or false
  }

  assert constraint {
    input and true
  }
}
````

Bei diesem Modell wurden für den Namen `input` 2 Symbole  `MySubject.input` und `req_has_attr_input.input` aufgelöst. Mit dem entfernen der impliziten Subject-Auflösung wird nun nur noch `req_has_attr_input.input` aufgelöst.