### PR TITLE
Moved SysMLQualifiedName to SysMLv2.mc4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,4 +25,4 @@ assertj_version    = 3.21.0
 junit_version      = 5.8.2
 
 # Version of published artifacts
-version            = 7.8.75
+version            = 7.8.76

--- a/language/src/main/grammars/de/monticore/lang/SysMLBasis.mc4
+++ b/language/src/main/grammars/de/monticore/lang/SysMLBasis.mc4
@@ -136,17 +136,6 @@ component grammar SysMLBasis
    * ##################################################################
    */
 
-  SysMLQualifiedName extends MCQualifiedName =
-    Name (("::" | ".") Name)* ;
-
-  astrule SysMLQualifiedName =
-    method public List<String> getPartsList() {
-      return getNameList();
-    }
-    method public String getBaseName() {
-      return getPartsList().get(getPartsList().size()-1);
-    } ;
-
   token MultilineNote =
      "//*" .*? "*/"  : -> channel(HIDDEN);
 

--- a/language/src/main/grammars/de/monticore/lang/SysMLv2.mc4
+++ b/language/src/main/grammars/de/monticore/lang/SysMLv2.mc4
@@ -16,6 +16,17 @@ grammar SysMLv2 extends SysMLExpressions,
 
   SysMLModel = SysMLElement* ;
 
+  SysMLQualifiedName extends MCQualifiedName =
+      Name (("::" | ".") Name)* ;
+
+    astrule SysMLQualifiedName =
+      method public List<String> getPartsList() {
+        return getNameList();
+      }
+      method public String getBaseName() {
+        return getPartsList().get(getPartsList().size()-1);
+      } ;
+
   // Bug in MontiCore führt dazu, dass es nur hier funktioniert
   @Override
   token Char = "doNotParseThisEverAgain";

--- a/language/src/main/java/de/monticore/lang/sysmlbasis/_prettyprint/SysMLBasisPrettyPrinter.java
+++ b/language/src/main/java/de/monticore/lang/sysmlbasis/_prettyprint/SysMLBasisPrettyPrinter.java
@@ -1,6 +1,5 @@
 package de.monticore.lang.sysmlbasis._prettyprint;
 
-import de.monticore.lang.sysmlbasis._ast.ASTSysMLQualifiedName;
 import de.monticore.prettyprint.CommentPrettyPrinter;
 import de.monticore.prettyprint.IndentPrinter;
 
@@ -11,25 +10,4 @@ public class SysMLBasisPrettyPrinter extends SysMLBasisPrettyPrinterTOP {
   public SysMLBasisPrettyPrinter(IndentPrinter printer, boolean printComments) {
     super(printer, printComments);
   }
-
-  // Fix pretty-print of SysMLQualifiedName with the intent of reproducing impl. of MCQualifiedName
-  @Override
-  public  void handle (ASTSysMLQualifiedName node) {
-    if (this.isPrintComments()) {
-      CommentPrettyPrinter.printPreComments(node, getPrinter());
-    }
-    Iterator<String> iter_name = node.getNameList().iterator();
-    if (iter_name.hasNext()) {
-      getPrinter().print(iter_name.next());
-      while (iter_name.hasNext()) {
-        getPrinter().stripTrailing();
-        getPrinter().print(".");
-        getPrinter().print(iter_name.next());
-      }
-    }
-    if (this.isPrintComments()) {
-      CommentPrettyPrinter.printPostComments(node, getPrinter());
-    }
-  }
-
 }

--- a/language/src/main/java/de/monticore/lang/sysmlv2/_ast/ASTSysMLQualifiedName.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/_ast/ASTSysMLQualifiedName.java
@@ -1,4 +1,4 @@
-package de.monticore.lang.sysmlbasis._ast;
+package de.monticore.lang.sysmlv2._ast;
 
 import de.se_rwth.commons.Names;
 

--- a/language/src/main/java/de/monticore/lang/sysmlv2/_prettyprint/SysMLv2PrettyPrinter.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/_prettyprint/SysMLv2PrettyPrinter.java
@@ -1,0 +1,36 @@
+package de.monticore.lang.sysmlv2._prettyprint;
+
+import de.monticore.lang.sysmlv2._ast.ASTSysMLQualifiedName;
+import de.monticore.prettyprint.CommentPrettyPrinter;
+import de.monticore.prettyprint.IndentPrinter;
+
+import java.util.Iterator;
+
+public class SysMLv2PrettyPrinter extends SysMLv2PrettyPrinterTOP {
+
+  public SysMLv2PrettyPrinter(IndentPrinter printer, boolean printComments) {
+    super(printer, printComments);
+  }
+
+  // Fix pretty-print of SysMLQualifiedName with the intent of reproducing impl. of MCQualifiedName
+  @Override
+  public void handle(ASTSysMLQualifiedName node) {
+    if (this.isPrintComments()) {
+      CommentPrettyPrinter.printPreComments(node, getPrinter());
+    }
+
+    Iterator<String> iterName = node.getNameList().iterator();
+    if (iterName.hasNext()) {
+      getPrinter().print(iterName.next());
+      while (iterName.hasNext()) {
+        getPrinter().stripTrailing();
+        getPrinter().print(".");
+        getPrinter().print(iterName.next());
+      }
+    }
+
+    if (this.isPrintComments()) {
+      CommentPrettyPrinter.printPostComments(node, getPrinter());
+    }
+  }
+}

--- a/language/src/main/java/de/monticore/lang/sysmlv2/types/SysMLBasisTypesPrettyPrinter.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/types/SysMLBasisTypesPrettyPrinter.java
@@ -1,7 +1,7 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.lang.sysmlv2.types;
 
-import de.monticore.lang.sysmlbasis._ast.ASTSysMLQualifiedName;
+import de.monticore.lang.sysmlv2._ast.ASTSysMLQualifiedName;
 import de.monticore.lang.sysmlbasis._visitor.SysMLBasisHandler;
 import de.monticore.lang.sysmlbasis._visitor.SysMLBasisTraverser;
 import de.monticore.lang.sysmlbasis._visitor.SysMLBasisVisitor2;


### PR DESCRIPTION
### Changed

- Vorher: SysMLQualifiedName in SysMLBasis.mc4
- Jetzt: SysMLQualifiedName in SysMLv2.mc4
- prettyprinting handler function wurde auch in den sysmlv2 ordner verschoben

### Neue Zeiten in millisekunden

#### Test.sysml:
Vorher Average  : 2965,53143333333
Nachher Average  : 2946,38178
Verbesserung: ~0.65%


#### Ordner language\src\test\resources\cocos\actions\ 
Vorher Average  : 15171,40076
Nachher Average  : 14724,5840733333
Verbesserung: ~3%
 
