### PR TITLE
#382 KerML-Symbole als BasicSymbols exportieren

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,4 +25,4 @@ assertj_version    = 3.21.0
 junit_version      = 5.8.2
 
 # Version of published artifacts
-version            = 7.8.74
+version            = 7.8.75

--- a/kerml/src/main/grammars/de/monticore/lang/KerMLElements.mc4
+++ b/kerml/src/main/grammars/de/monticore/lang/KerMLElements.mc4
@@ -18,8 +18,8 @@ component grammar KerMLElements
         ("as" Name)?
         ("{" KerMLElement* "}" | ";");
 
-    Datatype implements KerMLElement =
-        Modifier "datatype" MCQualifiedName (KerMLRelationClause)*
+    symbol scope Datatype implements KerMLElement =
+        Modifier "datatype" name:Name (KerMLRelationClause)*
         ("{" (KerMLElement)* "}" | ";");
 
     Classifier implements KerMLElement =

--- a/kerml/src/main/java/de/monticore/lang/kermlparts/symboltable/adapters/Datatype2TypeSymbolAdapter.java
+++ b/kerml/src/main/java/de/monticore/lang/kermlparts/symboltable/adapters/Datatype2TypeSymbolAdapter.java
@@ -1,0 +1,47 @@
+package de.monticore.lang.kermlparts.symboltable.adapters;
+
+import com.google.common.base.Preconditions;
+import de.monticore.lang.kermlelements._symboltable.DatatypeSymbol;
+import de.monticore.symbols.basicsymbols.BasicSymbolsMill;
+import de.monticore.symbols.basicsymbols._symboltable.IBasicSymbolsScope;
+import de.monticore.symbols.basicsymbols._symboltable.TypeSymbol;
+import de.se_rwth.commons.SourcePosition;
+
+public class Datatype2TypeSymbolAdapter extends TypeSymbol {
+  protected DatatypeSymbol adaptee;
+
+  public Datatype2TypeSymbolAdapter(DatatypeSymbol adaptee) {
+    super(Preconditions.checkNotNull(adaptee.getName()));
+    this.adaptee = adaptee;
+    IBasicSymbolsScope spanned = BasicSymbolsMill.scope();
+    spanned.setName(adaptee.getName());
+    this.setSpannedScope(spanned);
+  }
+
+  public DatatypeSymbol getAdaptee() {
+    return adaptee;
+  }
+
+  @Override
+  public void setName(String name) {
+    Preconditions.checkNotNull(name);
+    Preconditions.checkArgument(!name.isBlank());
+    getAdaptee().setName(name);
+  }
+
+  @Override
+  public String getName() {
+    return getAdaptee().getName();
+  }
+
+  @Override
+  public String getFullName() {
+    return getAdaptee().getFullName();
+  }
+
+  @Override
+  public SourcePosition getSourcePosition() {
+    return getAdaptee().getSourcePosition();
+  }
+}
+

--- a/kerml/src/test/java/symboltable/KerMLTestRunner.java
+++ b/kerml/src/test/java/symboltable/KerMLTestRunner.java
@@ -1,0 +1,79 @@
+package symboltable;
+
+import de.monticore.lang.kerml.KerMLMill;
+import de.monticore.lang.kerml.KerMLTool;
+import de.monticore.lang.kerml._ast.ASTKerMLModel;
+import de.monticore.lang.kermlelements._ast.ASTDatatype;
+import de.monticore.lang.kermlelements._visitor.KerMLElementsVisitor2;
+import de.monticore.symbols.basicsymbols.BasicSymbolsMill;
+import de.monticore.symbols.basicsymbols._symboltable.BasicSymbolsSymbols2Json;
+import de.monticore.symbols.basicsymbols._symboltable.IBasicSymbolsArtifactScope;
+import de.monticore.lang.kermlparts.symboltable.adapters.Datatype2TypeSymbolAdapter;
+import de.se_rwth.commons.logging.Log;
+
+import java.io.File;
+import java.io.FileWriter;
+
+public class KerMLTestRunner {
+
+  public static class DatatypeExtractor implements KerMLElementsVisitor2 {
+    private IBasicSymbolsArtifactScope exportScope;
+
+    public DatatypeExtractor(IBasicSymbolsArtifactScope exportScope) {
+      this.exportScope = exportScope;
+    }
+
+    @Override
+    public void visit(ASTDatatype node) {
+      if (node.isPresentSymbol()) {
+        exportScope.add(new Datatype2TypeSymbolAdapter(node.getSymbol()));
+      }
+    }
+  }
+
+  public static void main(String[] args) {
+    Log.init();
+    Log.enableFailQuick(false);
+
+    try {
+      KerMLTool tool = new KerMLTool();
+      tool.init();
+      BasicSymbolsMill.init();
+
+      String modelPath = "kerml/src/test/resources/KernelDataTypeLibrary/ScalarValues.kerml";
+      String jsonOutputPath = "kerml/target/symbols/ScalarValues.json";
+
+      ASTKerMLModel ast = tool.parse(modelPath);
+
+      if (ast != null) {
+        tool.createSymbolTable(ast);
+
+        IBasicSymbolsArtifactScope exportScope = BasicSymbolsMill.artifactScope();
+        exportScope.setName("ScalarValues");
+        exportScope.setPackageName("");
+
+        var traverser = KerMLMill.traverser();
+        traverser.add4KerMLElements(new DatatypeExtractor(exportScope));
+        ast.accept(traverser);
+
+        BasicSymbolsSymbols2Json symbols2Json = new BasicSymbolsSymbols2Json();
+        String jsonString = symbols2Json.serialize(exportScope);
+
+        File outFile = new File(jsonOutputPath);
+        outFile.getParentFile().mkdirs();
+        FileWriter writer = new FileWriter(outFile);
+        writer.write(jsonString);
+        writer.close();
+
+        System.out.println("\nJSON-File was generated");
+        System.out.println(outFile.getAbsolutePath());
+      } else {
+        System.err.println("\nModel couldnt be parsed. Check if Model exists.");
+      }
+
+    } catch (Exception e) {
+      System.err.println("\nError occured!");
+      e.printStackTrace();
+    }
+  }
+}


### PR DESCRIPTION
### Changes 
- Benutze den Export von Symbolen (tool.storeSymbols(scope, path)) um die Symbolinformationen einer KerMLTestfile in JSON-Format zu konvertieren. (Closes Issue 370)
- Added an adapter from Datatype to TypeSymbol (Closes Issue 382).
