### PR TITLE
Fix/function operation arguments master

### DIFF
--- a/language/src/main/grammars/de/monticore/lang/SysMLExpressions.mc4
+++ b/language/src/main/grammars/de/monticore/lang/SysMLExpressions.mc4
@@ -111,7 +111,7 @@ component grammar SysMLExpressions
    * useful for chaining invocations in an effective data flow
    */
   SysMLFunctionOperationExpression implements Expression <291> =
-    Expression "->" Name (Arguments)?
+    Expression "->" SysMLQualifiedName (Arguments)?
     ("{" SysMLElement* inner:Expression "}")? ;
 
   // Eigentlich ist "^" der Name einer CalcDef aus den Domain Libraries

--- a/language/src/main/grammars/de/monticore/lang/SysMLExpressions.mc4
+++ b/language/src/main/grammars/de/monticore/lang/SysMLExpressions.mc4
@@ -110,8 +110,9 @@ component grammar SysMLExpressions
    * name of the function to be invoked and an argument list for any remaining arguments (see 7.4.9.4). This is
    * useful for chaining invocations in an effective data flow
    */
-  SysMLFunctionOperationExpression implements Expression =
-    Expression "->" Name ("(" (SysMLParameter || ",")* ")")? ("{" SysMLElement* inner:Expression "}")? ;
+  SysMLFunctionOperationExpression implements Expression <291> =
+    Expression "->" Name (Arguments)?
+    ("{" SysMLElement* inner:Expression "}")? ;
 
   // Eigentlich ist "^" der Name einer CalcDef aus den Domain Libraries
   CalcDefPowerExpression implements Expression =

--- a/language/src/test/java/parser/ExpressionParserTest.java
+++ b/language/src/test/java/parser/ExpressionParserTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import de.monticore.lang.sysmlexpressions._ast.ASTSysMLFunctionOperationExpression;
+import de.monticore.expressions.commonexpressions._ast.ASTFieldAccessExpression;
 
 import java.io.IOException;
 
@@ -111,6 +112,36 @@ public class ExpressionParserTest {
     assertThat(Log.getFindings()).isEmpty();
     assertThat(ast.get())
         .isInstanceOf(ASTSysMLFunctionOperationExpression.class);
+  }
+
+  /**
+   * Checks that qualified names on both sides of a function operation
+   * are parsed with the correct binding.
+   */
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "a.b->c.d",
+      "a::b->c::d",
+      "a::b->c.d",
+      "a.b->c::d"
+  })
+  public void testQualifiedNamesInFunctionOperation(String expr)
+      throws IOException {
+
+    var ast = parser.parse_StringExpression(expr);
+
+    assertThat(ast).isPresent();
+    assertThat(Log.getFindings()).isEmpty();
+    assertThat(ast.get())
+        .isInstanceOf(ASTSysMLFunctionOperationExpression.class);
+
+    var functionOperation =
+        (ASTSysMLFunctionOperationExpression) ast.get();
+
+    assertThat(functionOperation.getExpression())
+        .isInstanceOf(ASTFieldAccessExpression.class);
+    assertThat(functionOperation.getSysMLQualifiedName().getPartsList())
+        .containsExactly("c", "d");
   }
 
 }

--- a/language/src/test/java/parser/ExpressionParserTest.java
+++ b/language/src/test/java/parser/ExpressionParserTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import de.monticore.lang.sysmlexpressions._ast.ASTSysMLFunctionOperationExpression;
 
 import java.io.IOException;
 
@@ -80,6 +81,36 @@ public class ExpressionParserTest {
     assertThat(ast).isPresent();
     assertThat(Log.getFindings()).isEmpty();
     assertThat(ast.get()).isInstanceOf(ASTElementOfExpression.class);
+  }
+
+  @Test
+  public void testSysMLFunctionOperatorExprMinimal() throws IOException {
+    var ast = parser.parse_StringExpression("x->b()");
+
+    assertThat(ast).isPresent();
+    assertThat(Log.getFindings()).isEmpty();
+    assertThat(ast.get())
+        .isInstanceOf(ASTSysMLFunctionOperationExpression.class);
+  }
+
+  @Test
+  public void testSysMLFunctionOperatorExpr() throws IOException {
+    var ast = parser.parse_StringExpression("x->excludes(y)");
+
+    assertThat(ast).isPresent();
+    assertThat(Log.getFindings()).isEmpty();
+    assertThat(ast.get())
+        .isInstanceOf(ASTSysMLFunctionOperationExpression.class);
+  }
+
+  @Test
+  public void testSysMLFunctionOperatorExpr2() throws IOException {
+    var ast = parser.parse_StringExpression("x->excludes(y.z)");
+
+    assertThat(ast).isPresent();
+    assertThat(Log.getFindings()).isEmpty();
+    assertThat(ast.get())
+        .isInstanceOf(ASTSysMLFunctionOperationExpression.class);
   }
 
 }


### PR DESCRIPTION
This PR adds support for qualified names in function operation expressions.

Function names following the -> operator can now be qualified using both . and ::. The parser tests cover all combinations of qualified names on both sides of the function operation:

a.b->c.d
a::b->c::d
a::b->c.d
a.b->c::d

The existing parser test was updated to use the generated SysMLQualifiedName AST node.

(see #190 )