### PR TITLE
Moved Dependency to SysMLv2.mc4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,4 +25,4 @@ assertj_version    = 3.21.0
 junit_version      = 5.8.2
 
 # Version of published artifacts
-version            = 7.8.76
+version            = 7.8.77

--- a/language/src/main/grammars/de/monticore/lang/SysMLBasis.mc4
+++ b/language/src/main/grammars/de/monticore/lang/SysMLBasis.mc4
@@ -275,12 +275,6 @@ component grammar SysMLBasis
   // Inline-Variante für das "first" vor dem "then"
   interface IInlineOccurrenceUsage ;
 
-  Dependency implements SysMLElement =
-    Modifier UserDefinedKeyword* "dependency" (Name? "from")? sources:(MCQualifiedName || ",")* "to" targets:(MCQualifiedName || ",")+
-    ("{"
-       SysMLElement*
-     "}" | ";");
-
   // Used regularly in successions
   Endpoint =
     MCQualifiedName SysMLCardinality? Specialization* ;

--- a/language/src/main/grammars/de/monticore/lang/SysMLv2.mc4
+++ b/language/src/main/grammars/de/monticore/lang/SysMLv2.mc4
@@ -65,4 +65,10 @@ grammar SysMLv2 extends SysMLExpressions,
       SysMLElement*
     "}" | ";") ;
 
+  Dependency implements SysMLElement =
+    Modifier UserDefinedKeyword* "dependency" (Name? "from")? sources:(MCQualifiedName || ",")* "to" targets:(MCQualifiedName || ",")+
+    ("{"
+       SysMLElement*
+     "}" | ";");
+
 }

--- a/language/src/main/java/de/monticore/lang/sysmlparts/_ast/ASTPartDef.java
+++ b/language/src/main/java/de/monticore/lang/sysmlparts/_ast/ASTPartDef.java
@@ -1,10 +1,10 @@
 package de.monticore.lang.sysmlparts._ast;
 
-import de.monticore.lang.sysmlbasis._ast.ASTDependency;
 import de.monticore.lang.sysmlbasis._ast.ASTSpecialization;
 import de.monticore.lang.sysmlbasis._ast.ASTSysMLElement;
 import de.monticore.lang.sysmlbasis._ast.ASTSysMLRefinement;
 import de.monticore.lang.sysmlparts._symboltable.PartDefSymbol;
+import de.monticore.lang.sysmlv2._ast.ASTDependency;
 import de.monticore.types.mcbasictypes._ast.ASTMCType;
 import org.antlr.v4.runtime.misc.Pair;
 

--- a/language/src/main/java/de/monticore/lang/sysmlv2/_ast/ASTDependency.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/_ast/ASTDependency.java
@@ -1,4 +1,4 @@
-package de.monticore.lang.sysmlbasis._ast;
+package de.monticore.lang.sysmlv2._ast;
 
 public class ASTDependency extends ASTDependencyTOP {
 


### PR DESCRIPTION
#### Changed

- Dependency Definition wurde aus SysMLBasis.mc4 nach SysMLv2 verschoben

#### Messung der Zugriffsgeschwindigkeit (in ms)

Vorher: 3967,94315
Nachher: 3950,61572

Verbesserung: ~0,44%

