### PR TITLE
Moved SysMLReference to SysMLv2.mc4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,4 +25,4 @@ assertj_version    = 3.21.0
 junit_version      = 5.8.2
 
 # Version of published artifacts
-version            = 7.8.79
+version            = 7.8.80

--- a/language/src/main/grammars/de/monticore/lang/SysMLBasis.mc4
+++ b/language/src/main/grammars/de/monticore/lang/SysMLBasis.mc4
@@ -74,13 +74,6 @@ component grammar SysMLBasis
   SysMLRedefinition implements Specialization =
       (":>>" | "redefines") superTypes:(MCType || ",")+ SysMLCardinality?;
 
-  /**
-   * [An event occurence] is related to another occurrence usage,
-   * representing the occurring event, by a reference subsetting relationship, which is a special kind of subsetting
-   * relationship specified using the keyword references or the symbol ::>.
-   */
-  SysMLReference implements Specialization =
-      ("::>" | "references") superTypes:(MCType || ",")+ SysMLCardinality?;
 
   /**
    * Cardinality bei mehreren Typen macht wenig Sinn, aber die Grammatik und damit der AST werden sehr kompliziert, wenn

--- a/language/src/main/grammars/de/monticore/lang/SysMLBasis.mc4
+++ b/language/src/main/grammars/de/monticore/lang/SysMLBasis.mc4
@@ -74,7 +74,6 @@ component grammar SysMLBasis
   SysMLRedefinition implements Specialization =
       (":>>" | "redefines") superTypes:(MCType || ",")+ SysMLCardinality?;
 
-
   /**
    * Cardinality bei mehreren Typen macht wenig Sinn, aber die Grammatik und damit der AST werden sehr kompliziert, wenn
    * man versucht alle Eventualitäten durch die Grammatik abzudecken.

--- a/language/src/main/grammars/de/monticore/lang/SysMLv2.mc4
+++ b/language/src/main/grammars/de/monticore/lang/SysMLv2.mc4
@@ -71,4 +71,12 @@ grammar SysMLv2 extends SysMLExpressions,
        SysMLElement*
      "}" | ";");
 
+  /**
+     * [An event occurence] is related to another occurrence usage,
+     * representing the occurring event, by a reference subsetting relationship, which is a special kind of subsetting
+     * relationship specified using the keyword references or the symbol ::>.
+     */
+    SysMLReference implements Specialization =
+        ("::>" | "references") superTypes:(MCType || ",")+ SysMLCardinality?;
+
 }


### PR DESCRIPTION
#### Changed

SysMLReference wurde von SysMLBasis.mc4 nach SysMLv2.mc4 verschoben

#### Laufzet Verbesserung (in ms)

Vorher: 3936,228193
Nachher: 3925,00364

Verbesserung: ~0,29%