### PR TITLE
Use Arguments in SysMLFunctionOperationExpression #355

### DIFF
--- a/language/src/main/grammars/de/monticore/lang/SysMLExpressions.mc4
+++ b/language/src/main/grammars/de/monticore/lang/SysMLExpressions.mc4
@@ -119,7 +119,7 @@ component grammar SysMLExpressions
 
   SysMLFunctionOperationExpression implements Expression <291> =
     Expression "->" MCQualifiedName
-    ("(" (SysMLParameter || ",")* ")")?
+    (Arguments)?
     (body:SysMLBodyExpression)? ;
 
   // Eigentlich ist "^" der Name einer CalcDef aus den Domain Libraries

--- a/language/src/test/java/parser/ExpressionParserTest.java
+++ b/language/src/test/java/parser/ExpressionParserTest.java
@@ -125,4 +125,22 @@ public class ExpressionParserTest {
     assertThat(functionOperation.getMCQualifiedName().getPartsList())
         .containsExactly("c", "d");
   }
+
+  /**
+   * Checks that a function operation with arguments is parsed directly as
+   * ASTSysMLFunctionOperationExpression, not wrapped in an ASTCallExpression.
+   */
+  @Test
+  public void testFunctionOperationWithArguments() throws IOException {
+    var ast = parser.parse_StringExpression("x->b(y)");
+
+    assertThat(ast).isPresent();
+    assertThat(Log.getFindings()).isEmpty();
+    assertThat(ast.get()).isInstanceOf(ASTSysMLFunctionOperationExpression.class);
+    assertThat(ast.get()).isNotInstanceOf(ASTCallExpression.class);
+
+    var functionOperation = (ASTSysMLFunctionOperationExpression) ast.get();
+    assertThat(functionOperation.getMCQualifiedName().getPartsList()).containsExactly("b");
+    assertThat(functionOperation.getArguments().getExpressionList()).hasSize(1);
+  }
 }


### PR DESCRIPTION
`SysMLFunctionOperationExpression` now uses the standard `Arguments` nonterminal instead of a custom `SysMLParameter` list, aligning it with the MC standard (e.g. `ASTCallExpression`). 