### PR TITLE
#392 fixed Fullnames

### DIFF
--- a/kerml/src/main/grammars/de/monticore/lang/KerMLElements.mc4
+++ b/kerml/src/main/grammars/de/monticore/lang/KerMLElements.mc4
@@ -7,8 +7,8 @@ component grammar KerMLElements
 {
     DocBlock implements KerMLElement= "doc";
 
-    PackageDeclaration implements KerMLElement=
-        Modifier  ("standard")? ("library")? "package" name:MCQualifiedName
+    symbol scope PackageDeclaration implements KerMLElement=
+        Modifier  ("standard")? ("library")? "package" name:Name
         ( "{" (KerMLElement)* "}");
 
     KerMLImportStatement extends MCImportStatement implements KerMLElement =


### PR DESCRIPTION
### Changes 
- Change the grammar Packename definition to be a symbol scope to have our adapter return the correct fullnames. (Closes Issue 392)