### PR TITLE
7.8.80: Kompatibilität zwischen GenericTypes von kompatiblen Typen

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,4 +25,4 @@ assertj_version    = 3.21.0
 junit_version      = 5.8.2
 
 # Version of published artifacts
-version            = 7.8.79
+version            = 7.8.80

--- a/language/src/main/java/de/monticore/lang/sysmlv2/SysMLv2Tool.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/SysMLv2Tool.java
@@ -502,5 +502,4 @@ public class SysMLv2Tool extends SysMLv2ToolTOP {
         "de.monticore.cd4codebasis._symboltable.CDMethodSignatureSymbol",
         new MethodSymbolDeSer());
   }
-
 }

--- a/language/src/main/java/de/monticore/lang/sysmlv2/SysMLv2Tool.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/SysMLv2Tool.java
@@ -1,8 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.lang.sysmlv2;
 
-import de.monticore.expressions.commonexpressions._ast.ASTFieldAccessExpression;
-import de.monticore.expressions.expressionsbasis._ast.ASTNameExpression;
 import de.monticore.lang.componentconnector.SerializationUtil;
 import de.monticore.lang.sysmlactions._cocos.SysMLActionsASTActionDefCoCo;
 import de.monticore.lang.sysmlconstraints._cocos.SysMLConstraintsASTConstraintDefCoCo;
@@ -503,22 +501,6 @@ public class SysMLv2Tool extends SysMLv2ToolTOP {
     SysMLv2Mill.globalScope().putSymbolDeSer(
         "de.monticore.cd4codebasis._symboltable.CDMethodSignatureSymbol",
         new MethodSymbolDeSer());
-  }
-
-  /**
-   * Baut einen Typ-basierten qualifizierten Namen für Port-Resolution in Requirements.
-   * Für llr1.input.val mit llr1 vom Typen Inverter_LLR1 wird "Inverter_LLR1.input.val" zurückgegeben.
-   */
-  public static String buildTypeBasedPortName(ASTFieldAccessExpression fieldAccess) {
-    if(fieldAccess.getExpression() instanceof ASTNameExpression){
-      return SysMLTypeCheck3.typeOf(fieldAccess.getExpression())
-        .printFullName()
-        + "."
-        + fieldAccess.getName();
-    }
-    return buildTypeBasedPortName(
-      (ASTFieldAccessExpression)fieldAccess.getExpression()
-    ) + "." + fieldAccess.getName();
   }
 
 }

--- a/language/src/main/java/de/monticore/lang/sysmlv2/SysMLv2Tool.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/SysMLv2Tool.java
@@ -1,6 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.lang.sysmlv2;
 
+import de.monticore.expressions.commonexpressions._ast.ASTFieldAccessExpression;
+import de.monticore.expressions.expressionsbasis._ast.ASTNameExpression;
 import de.monticore.lang.componentconnector.SerializationUtil;
 import de.monticore.lang.sysmlactions._cocos.SysMLActionsASTActionDefCoCo;
 import de.monticore.lang.sysmlconstraints._cocos.SysMLConstraintsASTConstraintDefCoCo;
@@ -502,4 +504,21 @@ public class SysMLv2Tool extends SysMLv2ToolTOP {
         "de.monticore.cd4codebasis._symboltable.CDMethodSignatureSymbol",
         new MethodSymbolDeSer());
   }
+
+  /**
+   * Baut einen Typ-basierten qualifizierten Namen für Port-Resolution in Requirements.
+   * Für llr1.input.val mit llr1 vom Typen Inverter_LLR1 wird "Inverter_LLR1.input.val" zurückgegeben.
+   */
+  public static String buildTypeBasedPortName(ASTFieldAccessExpression fieldAccess) {
+    if(fieldAccess.getExpression() instanceof ASTNameExpression){
+      return SysMLTypeCheck3.typeOf(fieldAccess.getExpression())
+        .printFullName()
+        + "."
+        + fieldAccess.getName();
+    }
+    return buildTypeBasedPortName(
+      (ASTFieldAccessExpression)fieldAccess.getExpression()
+    ) + "." + fieldAccess.getName();
+  }
+
 }

--- a/language/src/main/java/de/monticore/lang/sysmlv2/types3/SysMLCommonExpressionsTypeVisitor.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/types3/SysMLCommonExpressionsTypeVisitor.java
@@ -155,12 +155,17 @@ public class SysMLCommonExpressionsTypeVisitor extends CommonExpressionsTypeVisi
       } else if (expr.getExpression() instanceof ASTNameExpression) {
         optPort = ((IComponentConnectorScope) expr.getEnclosingScope()).resolvePort(SysMLv2Mill.prettyPrint(expr, false));
       } else if (
-        expr.getExpression() instanceof ASTFieldAccessExpression &&
-        expr.getEnclosingScope().getAstNode() instanceof ASTRequirementUsage
+        expr.getExpression() instanceof ASTFieldAccessExpression
       ) {
-        // Requirement-spezifisch: Verwende Typ-basierten Namen statt Instanz-Namen
-        String typeBasedName = SysMLv2Tool.buildTypeBasedPortName(expr);
-        optPort = ((IComponentConnectorScope) expr.getEnclosingScope()).resolvePort(typeBasedName);
+        String typeBasedNameBySource =
+          calculateExprFieldAccess((ASTFieldAccessExpression)(expr.getExpression()), false)
+            .get()
+            .getSourceInfo()
+            .getSourceSymbol()
+            .get()
+            .getFullName() + "." +expr.getName();
+
+        optPort = ((IComponentConnectorScope) expr.getEnclosingScope()).resolvePort(typeBasedNameBySource);
       }
 
       var innerTypeIsPortDef =  innerAsExprType.hasTypeInfo() &&

--- a/language/src/main/java/de/monticore/lang/sysmlv2/types3/SysMLCommonExpressionsTypeVisitor.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/types3/SysMLCommonExpressionsTypeVisitor.java
@@ -13,6 +13,7 @@ import de.monticore.lang.componentconnector.StreamTimingUtil;
 import de.monticore.lang.componentconnector._symboltable.IComponentConnectorScope;
 import de.monticore.lang.sysmlactions._ast.ASTAssignmentActionUsage;
 import de.monticore.lang.sysmlconstraints._ast.ASTConstraintUsage;
+import de.monticore.lang.sysmlconstraints._ast.ASTRequirementUsage;
 import de.monticore.lang.sysmlexpressions._ast.ASTConditionalNotExpression;
 import de.monticore.lang.sysmlexpressions._ast.ASTInfinity;
 import de.monticore.lang.sysmlexpressions._ast.ASTSubsetEquationExpression;
@@ -36,6 +37,7 @@ import de.monticore.lang.sysmlstates._ast.ASTStateUsage;
 import de.monticore.lang.sysmlstates._symboltable.StateDefSymbol;
 import de.monticore.lang.sysmlstates._symboltable.StateUsageSymbol;
 import de.monticore.lang.sysmlv2.SysMLv2Mill;
+import de.monticore.lang.sysmlv2.SysMLv2Tool;
 import de.monticore.lang.sysmlv2._symboltable.ISysMLv2ArtifactScope;
 import de.monticore.lang.sysmlv2._symboltable.ISysMLv2GlobalScope;
 import de.monticore.lang.sysmlv2._symboltable.ISysMLv2Scope;
@@ -152,6 +154,13 @@ public class SysMLCommonExpressionsTypeVisitor extends CommonExpressionsTypeVisi
             false));
       } else if (expr.getExpression() instanceof ASTNameExpression) {
         optPort = ((IComponentConnectorScope) expr.getEnclosingScope()).resolvePort(SysMLv2Mill.prettyPrint(expr, false));
+      } else if (
+        expr.getExpression() instanceof ASTFieldAccessExpression &&
+        expr.getEnclosingScope().getAstNode() instanceof ASTRequirementUsage
+      ) {
+        // Requirement-spezifisch: Verwende Typ-basierten Namen statt Instanz-Namen
+        String typeBasedName = SysMLv2Tool.buildTypeBasedPortName(expr);
+        optPort = ((IComponentConnectorScope) expr.getEnclosingScope()).resolvePort(typeBasedName);
       }
 
       var innerTypeIsPortDef =  innerAsExprType.hasTypeInfo() &&

--- a/language/src/main/java/de/monticore/lang/sysmlv2/types3/SysMLSymTypeRelations.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/types3/SysMLSymTypeRelations.java
@@ -6,6 +6,9 @@ import de.monticore.types3.util.BuiltInTypeRelations;
 import de.monticore.types3.util.SymTypeCompatibilityCalculator;
 import de.monticore.types3.util.SymTypeRelationsDefaultDelegatee;
 
+import java.util.HashSet;
+import java.util.Set;
+
 public abstract class SysMLSymTypeRelations extends OCLSymTypeRelations {
 
   public static void init() {
@@ -42,14 +45,116 @@ public abstract class SysMLSymTypeRelations extends OCLSymTypeRelations {
       compatibilityDelegate = new SymTypeCompatibilityCalculator() {
         @Override
         public boolean isCompatible(
-            SymTypeExpression target,
-            SymTypeExpression source) {
+          SymTypeExpression target,
+          SymTypeExpression source
+        ) {
           return (super.isCompatible(target, source) ||
             (
               builtInRelationsDelegate.isBoolean(target) &&
               builtInRelationsDelegate.isBoolean(source)
-            )
+            ) ||
+            areCompatibleGenericTypes(target, source)
           );
+        }
+
+        /**
+         * Prüft, ob zwei generische Typen miteinander kompatibel sind.
+         * Zwei generische Typen gelten als kompatibel, wenn:
+         * - beide Seiten generische Typen sind
+         * - denselben Basistyp besitzen
+         * - gleich viele Typargumente haben und jedes Typargument paarweise
+         *   kompatibel ist
+         */
+        private boolean areCompatibleGenericTypes(
+          SymTypeExpression target,
+          SymTypeExpression source
+        ) {
+          if (!target.isGenericType() || !source.isGenericType()) {
+            return false;
+          }
+
+          var targetGeneric = target.asGenericType();
+          var sourceGeneric = source.asGenericType();
+
+          if (!targetGeneric.getTypeInfo().getFullName()
+              .equals(sourceGeneric.getTypeInfo().getFullName())) {
+            return false;
+          }
+
+          if (targetGeneric.getArgumentList().size()
+              != sourceGeneric.getArgumentList().size()) {
+            return false;
+          }
+
+          for (int i = 0; i < targetGeneric.getArgumentList().size(); i++) {
+            var targetArgument = targetGeneric.getArgument(i);
+            var sourceArgument = sourceGeneric.getArgument(i);
+
+            if (!areCompatibleGenericArguments(targetArgument, sourceArgument)) {
+              return false;
+            }
+          }
+
+          return true;
+        }
+
+        /**
+         * Prüft, ob zwei Typargumente eines generischen Typs kompatibel sind.
+         * Vor dem Vergleich werden beide Argumente normalisiert. Falls eines
+         * der normalisierten Argumente ein Union-Typ ist, müssen beide Seiten
+         * Union-Typen sein.
+         * In allen anderen Fällen wird die normale Typkompatibilität verwendet.
+         */
+        private boolean areCompatibleGenericArguments(
+          SymTypeExpression targetArgument,
+          SymTypeExpression sourceArgument
+        ) {
+          var normalizedTarget = normalize(targetArgument);
+          var normalizedSource = normalize(sourceArgument);
+
+          if (normalizedTarget.isUnionType() || normalizedSource.isUnionType()) {
+            return normalizedTarget.isUnionType()
+                && normalizedSource.isUnionType()
+                && areCompatibleUnionTypes(normalizedTarget, normalizedSource);
+          }
+
+          return isCompatible(normalizedTarget, normalizedSource);
+        }
+
+        /**
+         * Prüft, ob zwei Union-Typen kompatibel sind.
+         *
+         * Das ist nötig, weil z. B. {@code <5, true>} als generischer Typ mit genau
+         * einem Typargument {@code Union(int, boolean)} betrachtet wird.
+         */
+        private boolean areCompatibleUnionTypes(
+          SymTypeExpression target,
+          SymTypeExpression source
+        ) {
+          Set<SymTypeExpression> targetTypes =
+              new HashSet<>(target.asUnionType().getUnionizedTypeSet());
+          Set<SymTypeExpression> sourceTypes =
+              new HashSet<>(source.asUnionType().getUnionizedTypeSet());
+
+          if (targetTypes.size() != sourceTypes.size()) {
+            return false;
+          }
+
+          for (SymTypeExpression targetType : targetTypes) {
+            var matchingSourceType = sourceTypes.stream()
+              .filter(
+                sourceType -> isCompatible(targetType, sourceType)
+              )
+              .findAny();
+
+            if (matchingSourceType.isEmpty()) {
+              return false;
+            }
+
+            sourceTypes.remove(matchingSourceType.get());
+          }
+
+          return sourceTypes.isEmpty();
         }
       };
     }

--- a/language/src/test/java/typecheck/CompareGenericTypesTest.java
+++ b/language/src/test/java/typecheck/CompareGenericTypesTest.java
@@ -115,15 +115,9 @@ public class CompareGenericTypesTest {
   public void test4CompatibleGenericTypes(String expression) throws IOException {
     var type = typeOfConstraintExpression(expression);
 
-    System.out.println("TypeCheck calculated: " + type.getTypeInfo().getFullName());
     assertTrue(type.isPrimitive());
     assertThat(type.printFullName()).isEqualTo("boolean");
-    System.out.println("Checking Log after TypeCheck...");
-    for (var finding : Log.getFindings()) {
-      System.out.println(finding);
-    }
     assertTrue(Log.getFindings().isEmpty());
-    System.out.println("Done");
   }
 
   @ParameterizedTest
@@ -136,16 +130,8 @@ public class CompareGenericTypesTest {
   public void test4IncompatibleGenericTypes(String expression) throws IOException {
     var type = typeOfConstraintExpression(expression);
 
-    System.out.println("TypeCheck calculated: " +
-      (type.isObscureType() ? "ObscureType" : type.getTypeInfo().getFullName())
-    );
     assertTrue(type.isObscureType());
-    System.out.println("Checking Log after TypeCheck...");
-    for (var finding : Log.getFindings()) {
-      System.out.println(finding);
-    }
     assertFalse(Log.getFindings().isEmpty());
-    System.out.println("Done");
   }
 
   protected de.monticore.types.check.SymTypeExpression typeOfConstraintExpression(
@@ -167,12 +153,7 @@ public class CompareGenericTypesTest {
 
     var ast = parser.parse_String(model);
 
-    System.out.println("Parsing model...");
     assertThat(ast).isPresent();
-    System.out.println("Checking Log after parsing...");
-    for (var finding : Log.getFindings()) {
-      System.out.println(finding);
-    }
     assertThat(Log.getFindings()).isEmpty();
 
     var astSysMLModel = ast.get();
@@ -185,7 +166,6 @@ public class CompareGenericTypesTest {
     var constraintUsage = ((ASTPartDef) astPartDef).getSysMLElement(3);
     var expr = ((ASTConstraintUsage) constraintUsage).getExpression();
 
-    System.out.println("TypeChecking...");
     return TypeCheck3.typeOf(expr);
   }
 }

--- a/language/src/test/java/typecheck/CompareGenericTypesTest.java
+++ b/language/src/test/java/typecheck/CompareGenericTypesTest.java
@@ -1,0 +1,191 @@
+package typecheck;
+
+import de.monticore.expressions.commonexpressions.types3.util.CommonExpressionsLValueRelations;
+import de.monticore.expressions.expressionsbasis.types3.ExpressionBasisTypeVisitor;
+import de.monticore.expressions.streamexpressions.types3.StreamExpressionsTypeVisitor;
+import de.monticore.lang.sysmlconstraints._ast.ASTConstraintUsage;
+import de.monticore.lang.sysmlparts._ast.ASTPartDef;
+import de.monticore.lang.sysmlparts._ast.ASTPartUsage;
+import de.monticore.lang.sysmlv2.SysMLv2Mill;
+import de.monticore.lang.sysmlv2.SysMLv2Tool;
+import de.monticore.lang.sysmlv2._parser.SysMLv2Parser;
+import de.monticore.lang.sysmlv2.types3.SysMLCommonExpressionsTypeVisitor;
+import de.monticore.lang.sysmlv2.types3.SysMLMCBasicTypesTypeVisitor;
+import de.monticore.lang.sysmlv2.types3.SysMLOCLExpressionsTypeVisitor;
+import de.monticore.lang.sysmlv2.types3.SysMLSetExpressionsTypeVisitor;
+import de.monticore.lang.sysmlv2.types3.SysMLSymTypeRelations;
+import de.monticore.lang.sysmlv2.types3.SysMLTypeCheck3;
+import de.monticore.lang.sysmlv2.types3.SysMLTypeVisitorOperatorCalculator;
+import de.monticore.lang.sysmlv2.types3.SysMLWithinScopeBasicSymbolResolver;
+import de.monticore.literals.mccommonliterals.types3.MCCommonLiteralsTypeVisitor;
+import de.monticore.types.check.SymTypeExpression;
+import de.monticore.types.mccollectiontypes.types3.MCCollectionSymTypeRelations;
+import de.monticore.types.mccollectiontypes.types3.MCCollectionTypesTypeVisitor;
+import de.monticore.types3.SymTypeRelations;
+import de.monticore.types3.Type4Ast;
+import de.monticore.types3.TypeCheck3;
+import de.monticore.types3.streams.StreamSymTypeRelations;
+import de.se_rwth.commons.logging.Log;
+import de.se_rwth.commons.logging.LogStub;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CompareGenericTypesTest {
+
+  private final SysMLv2Parser parser = new SysMLv2Parser();
+  private final SysMLv2Tool tool = new SysMLv2Tool();
+
+  @BeforeAll
+  public static void setup() {
+    LogStub.init();
+    SysMLv2Mill.init();
+  }
+
+  @BeforeEach
+  public void clear() {
+    Log.clearFindings();
+    tool.init();
+
+    var type4Ast = new Type4Ast();
+    var typeTraverser = SysMLv2Mill.inheritanceTraverser();
+
+    var forBasis = new ExpressionBasisTypeVisitor();
+    forBasis.setType4Ast(type4Ast);
+    typeTraverser.add4ExpressionsBasis(forBasis);
+
+    var forLiterals = new MCCommonLiteralsTypeVisitor();
+    forLiterals.setType4Ast(type4Ast);
+    typeTraverser.add4MCCommonLiterals(forLiterals);
+
+    var forCommon = new SysMLCommonExpressionsTypeVisitor();
+    forCommon.setType4Ast(type4Ast);
+    typeTraverser.add4CommonExpressions(forCommon);
+    typeTraverser.setCommonExpressionsHandler(forCommon);
+    typeTraverser.add4SysMLExpressions(forCommon);
+    typeTraverser.setSysMLExpressionsHandler(forCommon);
+
+    var forOcl = new SysMLOCLExpressionsTypeVisitor();
+    forOcl.setType4Ast(type4Ast);
+    typeTraverser.add4OCLExpressions(forOcl);
+    typeTraverser.add4SysMLExpressions(forOcl);
+
+    var forStreams = new StreamExpressionsTypeVisitor();
+    forStreams.setType4Ast(type4Ast);
+    typeTraverser.add4StreamExpressions(forStreams);
+
+    var forSets = new SysMLSetExpressionsTypeVisitor();
+    forSets.setType4Ast(type4Ast);
+    typeTraverser.add4SetExpressions(forSets);
+
+    var forBasicTypes = new SysMLMCBasicTypesTypeVisitor();
+    forBasicTypes.setType4Ast(type4Ast);
+    typeTraverser.add4MCBasicTypes(forBasicTypes);
+    typeTraverser.add4SysMLExpressions(forBasicTypes);
+
+    var forCollectionTypes = new MCCollectionTypesTypeVisitor();
+    forCollectionTypes.setType4Ast(type4Ast);
+    typeTraverser.add4MCCollectionTypes(forCollectionTypes);
+
+    StreamSymTypeRelations.init();
+    SysMLWithinScopeBasicSymbolResolver.init();
+    SysMLTypeVisitorOperatorCalculator.init();
+    CommonExpressionsLValueRelations.init();
+    MCCollectionSymTypeRelations.init();
+    SysMLSymTypeRelations.init();
+
+    new SysMLTypeCheck3(typeTraverser, type4Ast).setThisAsDelegate();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "input.val == <true>",
+      "input.val == <true> implies not(input.val == <false>)",
+      "input.val == inputMc.val",
+      "inputInt.val == < 5 >",
+      "< 4 , true> == < 2 , false>",
+  })
+  public void test4CompatibleGenericTypes(String expression) throws IOException {
+    var type = typeOfConstraintExpression(expression);
+
+    System.out.println("TypeCheck calculated: " + type.getTypeInfo().getFullName());
+    assertTrue(type.isPrimitive());
+    assertThat(type.printFullName()).isEqualTo("boolean");
+    System.out.println("Checking Log after TypeCheck...");
+    for (var finding : Log.getFindings()) {
+      System.out.println(finding);
+    }
+    assertTrue(Log.getFindings().isEmpty());
+    System.out.println("Done");
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "input.val == true",
+      "inputInt.val == 5 ",
+      "input.val == inputInt.val",
+      "inputInt.val == < 5 , true>",
+  })
+  public void test4IncompatibleGenericTypes(String expression) throws IOException {
+    var type = typeOfConstraintExpression(expression);
+
+    System.out.println("TypeCheck calculated: " +
+      (type.isObscureType() ? "ObscureType" : type.getTypeInfo().getFullName())
+    );
+    assertTrue(type.isObscureType());
+    System.out.println("Checking Log after TypeCheck...");
+    for (var finding : Log.getFindings()) {
+      System.out.println(finding);
+    }
+    assertFalse(Log.getFindings().isEmpty());
+    System.out.println("Done");
+  }
+
+  protected de.monticore.types.check.SymTypeExpression typeOfConstraintExpression(
+      String expression) throws IOException {
+    var model =
+        "private import ScalarValues::Boolean;" +
+        "port def Booleans { in attribute val: Boolean; }" +
+        "port def McBooleans { in attribute val: boolean; }" +
+        "port def Integers { in attribute val: int; }" +
+        "part def myPart { " +
+          "port input: Booleans;" +
+          "port inputMc: McBooleans;" +
+          "port inputInt: Integers;" +
+          "assert constraint e {" +
+            expression +
+          "}" +
+        "}"
+        ;
+
+    var ast = parser.parse_String(model);
+
+    System.out.println("Parsing model...");
+    assertThat(ast).isPresent();
+    System.out.println("Checking Log after parsing...");
+    for (var finding : Log.getFindings()) {
+      System.out.println(finding);
+    }
+    assertThat(Log.getFindings()).isEmpty();
+
+    var astSysMLModel = ast.get();
+    tool.createSymbolTable(astSysMLModel);
+    tool.completeSymbolTable(astSysMLModel);
+    tool.finalizeSymbolTable(astSysMLModel);
+
+    var sysmlelements = astSysMLModel.getSysMLElementList();
+    var astPartDef = sysmlelements.get(4);
+    var constraintUsage = ((ASTPartDef) astPartDef).getSysMLElement(3);
+    var expr = ((ASTConstraintUsage) constraintUsage).getExpression();
+
+    System.out.println("TypeChecking...");
+    return TypeCheck3.typeOf(expr);
+  }
+}

--- a/language/src/test/java/typecheck/CompareGenericTypesTest.java
+++ b/language/src/test/java/typecheck/CompareGenericTypesTest.java
@@ -4,6 +4,8 @@ import de.monticore.expressions.commonexpressions.types3.util.CommonExpressionsL
 import de.monticore.expressions.expressionsbasis.types3.ExpressionBasisTypeVisitor;
 import de.monticore.expressions.streamexpressions.types3.StreamExpressionsTypeVisitor;
 import de.monticore.lang.sysmlconstraints._ast.ASTConstraintUsage;
+import de.monticore.lang.sysmlconstraints._ast.ASTRequirementDef;
+import de.monticore.lang.sysmlconstraints._ast.ASTRequirementUsage;
 import de.monticore.lang.sysmlparts._ast.ASTPartDef;
 import de.monticore.lang.sysmlparts._ast.ASTPartUsage;
 import de.monticore.lang.sysmlv2.SysMLv2Mill;
@@ -29,6 +31,7 @@ import de.se_rwth.commons.logging.Log;
 import de.se_rwth.commons.logging.LogStub;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -132,6 +135,50 @@ public class CompareGenericTypesTest {
 
     assertTrue(type.isObscureType());
     assertFalse(Log.getFindings().isEmpty());
+  }
+
+  @Test
+  public void test4RequirementSubjectPortResolving() throws IOException {
+    var model =
+        "port def Booleans {" +
+          "in attribute val: boolean;" +
+        "}" +
+        "part def subjectPart{" +
+          "port input: Booleans;" +
+          "port output: ~Booleans;" +
+          "exhibit state behavior;" +
+        "}" +
+        "requirement 'Requirement' {" +
+          "subject subPart: subjectPart;" +
+          "attribute a: boolean;" +
+          "assert constraint {" +
+            "subPart.input.val == <a, Tick>" +
+          "}" +
+        "}"
+        ;
+
+    var ast = parser.parse_String(model);
+
+    assertThat(ast).isPresent();
+    assertThat(Log.getFindings()).isEmpty();
+
+    var astSysMLModel = ast.get();
+    tool.createSymbolTable(astSysMLModel);
+    tool.completeSymbolTable(astSysMLModel);
+    tool.finalizeSymbolTable(astSysMLModel);
+
+    var sysmlelements = astSysMLModel.getSysMLElementList();
+    var requirement = sysmlelements.get(2);
+    var constraintUsage = ((ASTRequirementUsage) requirement).getSysMLElement(2);
+    var expr = ((ASTConstraintUsage) constraintUsage).getExpression();
+
+    var type = TypeCheck3.typeOf(expr);
+
+    assertThat(ast).isPresent();
+    assertThat(Log.getFindings()).isEmpty();
+    assertTrue(type.isPrimitive());
+    assertThat(type.printFullName()).isEqualTo("boolean");
+    assertTrue(Log.getFindings().isEmpty());
   }
 
   protected de.monticore.types.check.SymTypeExpression typeOfConstraintExpression(


### PR DESCRIPTION
## Changed

- GenericTypes von kompatiblen Typen können nun miteinander verglichen werden. Zum Beispiel Streams von MC-boolean und ScalarValues::Boolean.