### PR TITLE
Moved KerMLCardinality to SysMLv2.mc4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,4 +25,4 @@ assertj_version    = 3.21.0
 junit_version      = 5.8.2
 
 # Version of published artifacts
-version            = 7.8.79
+version            = 7.8.80

--- a/language/src/main/grammars/de/monticore/lang/SysMLBasis.mc4
+++ b/language/src/main/grammars/de/monticore/lang/SysMLBasis.mc4
@@ -12,32 +12,6 @@ component grammar SysMLBasis
             de.monticore.UMLModifier                    // Modifier
 {
 
-  KerMLCardinality extends Cardinality =
-    "["
-    ( many:["*"]
-      {
-        //_builder.setLowerBound(0);_builder.setUpperBound(0);
-      } |
-      lowerBoundLit:NatLiteral
-      {
-        //_builder.setLowerBound(_builder.getLowerBoundLit().getValue());
-        //_builder.setUpperBound(_builder.getLowerBound());
-      } |
-      lowerExpr:Expression
-    )
-    ( ".." (
-      upperBoundLit:NatLiteral
-      {
-        //_builder.setUpperBound(_builder.getUpperBoundLit().getValue());
-      } |
-      noUpperLimit:["*"]
-      {
-       // _builder.setUpperBound(0);
-      } |
-      upperExpr:Expression
-    ) )?
-    "]" ;
-
   /*
    * ##################################################################
    * SysML Basis Symbole

--- a/language/src/main/grammars/de/monticore/lang/SysMLv2.mc4
+++ b/language/src/main/grammars/de/monticore/lang/SysMLv2.mc4
@@ -16,6 +16,32 @@ grammar SysMLv2 extends SysMLExpressions,
 
   SysMLModel = SysMLElement* ;
 
+  KerMLCardinality extends Cardinality =
+    "["
+    ( many:["*"]
+      {
+        //_builder.setLowerBound(0);_builder.setUpperBound(0);
+      } |
+      lowerBoundLit:NatLiteral
+      {
+        //_builder.setLowerBound(_builder.getLowerBoundLit().getValue());
+        //_builder.setUpperBound(_builder.getLowerBound());
+      } |
+      lowerExpr:Expression
+    )
+    ( ".." (
+      upperBoundLit:NatLiteral
+      {
+        //_builder.setUpperBound(_builder.getUpperBoundLit().getValue());
+      } |
+      noUpperLimit:["*"]
+      {
+       // _builder.setUpperBound(0);
+      } |
+      upperExpr:Expression
+    ) )?
+    "]" ;
+
   SysMLQualifiedName extends MCQualifiedName =
     Name (("::" | ".") Name)* ;
 

--- a/language/src/main/java/de/monticore/lang/sysmlv2/_ast/ASTKerMLCardinality.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/_ast/ASTKerMLCardinality.java
@@ -1,8 +1,4 @@
-package de.monticore.lang.sysmlbasis._ast;
-
-import de.monticore.expressions.expressionsbasis._ast.ASTLiteralExpression;
-import de.monticore.literals.mccommonliterals._ast.ASTNatLiteral;
-import de.se_rwth.commons.logging.Log;
+package de.monticore.lang.sysmlv2._ast;
 
 public class ASTKerMLCardinality extends ASTKerMLCardinalityTOP {
 


### PR DESCRIPTION
### Changed

- KerMLCardinality wurde von SysMLBasis.mc4 nach SysMLv2.mc4 verschoben

### Verbesserung (in ms)

Vorher Average: 3977,9939667
Nachher Average  : 3962,2543

Verbesserung ~0,4%