### PR TITLE
7.8.81: Load java.lang TypeSymbols

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,4 +25,4 @@ assertj_version    = 3.21.0
 junit_version      = 5.8.2
 
 # Version of published artifacts
-version            = 7.8.80
+version            = 7.8.81

--- a/language/build.gradle
+++ b/language/build.gradle
@@ -71,6 +71,7 @@ dependencies {
   implementation "de.monticore:monticore-runtime:$mc_version"
   implementation "de.monticore:monticore-grammar:$mc_version"
   implementation "de.monticore:stream-symbols:$mc_version"
+  implementation "de.monticore:class2mc:$mc_version"
   implementation "de.monticore.lang:ocl:$mc_version"
   implementation "commons-cli:commons-cli:$commons_cli_version"
 }

--- a/language/src/main/java/de/monticore/lang/sysmlv2/SysMLv2Mill.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/SysMLv2Mill.java
@@ -2,6 +2,7 @@
 package de.monticore.lang.sysmlv2;
 
 import de.monticore.symbols.basicsymbols.BasicSymbolsMill;
+import de.monticore.class2mc.OOClass2MCResolver;
 import de.monticore.ocl.types3.OCLSymTypeRelations;
 import de.monticore.types.check.SymTypeExpression;
 import de.monticore.types.mccollectiontypes.types3.MCCollectionSymTypeRelations;
@@ -46,12 +47,18 @@ public class SysMLv2Mill extends SysMLv2MillTOP {
     SysMLv2Tool.loadStreamSymbolsFromJar();
   }
 
+  public void initializeClass2MC() {
+    SysMLv2Mill.globalScope().addAdaptedTypeSymbolResolver(new OOClass2MCResolver());
+    SysMLv2Mill.globalScope().addAdaptedOOTypeSymbolResolver(new OOClass2MCResolver());
+  }
+
   /**
    * BasicSymbolsMill.initializePrimitives plus our own
    */
   public static void initializePrimitives() {
     BasicSymbolsMill.initializePrimitives();
     getMill()._initializePrimitives();
+    getMill().initializeClass2MC();
   }
 
   /**

--- a/language/src/main/java/de/monticore/lang/sysmlv2/types3/SysMLSymTypeRelations.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/types3/SysMLSymTypeRelations.java
@@ -38,20 +38,6 @@ public abstract class SysMLSymTypeRelations extends OCLSymTypeRelations {
           );
         }
       };
-
-      compatibilityDelegate = new SymTypeCompatibilityCalculator() {
-        @Override
-        public boolean isCompatible(
-            SymTypeExpression target,
-            SymTypeExpression source) {
-          return (super.isCompatible(target, source) ||
-            (
-              builtInRelationsDelegate.isBoolean(target) &&
-              builtInRelationsDelegate.isBoolean(source)
-            )
-          );
-        }
-      };
     }
   }
 }

--- a/language/src/test/java/typecheck/CompareTypesTest.java
+++ b/language/src/test/java/typecheck/CompareTypesTest.java
@@ -53,55 +53,6 @@ public class CompareTypesTest {
   public void clear() {
     Log.clearFindings();
     tool.init();
-
-    var type4Ast = new Type4Ast();
-    var typeTraverser = SysMLv2Mill.inheritanceTraverser();
-
-    var forBasis = new ExpressionBasisTypeVisitor();
-    forBasis.setType4Ast(type4Ast);
-    typeTraverser.add4ExpressionsBasis(forBasis);
-
-    var forLiterals = new MCCommonLiteralsTypeVisitor();
-    forLiterals.setType4Ast(type4Ast);
-    typeTraverser.add4MCCommonLiterals(forLiterals);
-
-    var forCommon = new SysMLCommonExpressionsTypeVisitor();
-    forCommon.setType4Ast(type4Ast);
-    typeTraverser.add4CommonExpressions(forCommon);
-    typeTraverser.setCommonExpressionsHandler(forCommon);
-    typeTraverser.add4SysMLExpressions(forCommon);
-    typeTraverser.setSysMLExpressionsHandler(forCommon);
-
-    var forOcl = new SysMLOCLExpressionsTypeVisitor();
-    forOcl.setType4Ast(type4Ast);
-    typeTraverser.add4OCLExpressions(forOcl);
-    typeTraverser.add4SysMLExpressions(forOcl);
-
-    var forStreams = new StreamExpressionsTypeVisitor();
-    forStreams.setType4Ast(type4Ast);
-    typeTraverser.add4StreamExpressions(forStreams);
-
-    var forSets = new SysMLSetExpressionsTypeVisitor();
-    forSets.setType4Ast(type4Ast);
-    typeTraverser.add4SetExpressions(forSets);
-
-    var forBasicTypes = new SysMLMCBasicTypesTypeVisitor();
-    forBasicTypes.setType4Ast(type4Ast);
-    typeTraverser.add4MCBasicTypes(forBasicTypes);
-    typeTraverser.add4SysMLExpressions(forBasicTypes);
-
-    var forCollectionTypes = new MCCollectionTypesTypeVisitor();
-    forCollectionTypes.setType4Ast(type4Ast);
-    typeTraverser.add4MCCollectionTypes(forCollectionTypes);
-
-    StreamSymTypeRelations.init();
-    SysMLWithinScopeBasicSymbolResolver.init();
-    SysMLTypeVisitorOperatorCalculator.init();
-    CommonExpressionsLValueRelations.init();
-    MCCollectionSymTypeRelations.init();
-    SysMLSymTypeRelations.init();
-
-    new SysMLTypeCheck3(typeTraverser, type4Ast).setThisAsDelegate();
   }
 
   @ParameterizedTest

--- a/language/src/test/java/typecheck/CompareTypesTest.java
+++ b/language/src/test/java/typecheck/CompareTypesTest.java
@@ -1,0 +1,160 @@
+package typecheck;
+
+import de.monticore.expressions.commonexpressions.types3.util.CommonExpressionsLValueRelations;
+import de.monticore.expressions.expressionsbasis.types3.ExpressionBasisTypeVisitor;
+import de.monticore.expressions.streamexpressions.types3.StreamExpressionsTypeVisitor;
+import de.monticore.lang.sysmlconstraints._ast.ASTConstraintUsage;
+import de.monticore.lang.sysmlparts._ast.ASTPartDef;
+import de.monticore.lang.sysmlparts._ast.ASTPartUsage;
+import de.monticore.lang.sysmlv2.SysMLv2Mill;
+import de.monticore.lang.sysmlv2.SysMLv2Tool;
+import de.monticore.lang.sysmlv2._parser.SysMLv2Parser;
+import de.monticore.lang.sysmlv2.types3.SysMLCommonExpressionsTypeVisitor;
+import de.monticore.lang.sysmlv2.types3.SysMLMCBasicTypesTypeVisitor;
+import de.monticore.lang.sysmlv2.types3.SysMLOCLExpressionsTypeVisitor;
+import de.monticore.lang.sysmlv2.types3.SysMLSetExpressionsTypeVisitor;
+import de.monticore.lang.sysmlv2.types3.SysMLSymTypeRelations;
+import de.monticore.lang.sysmlv2.types3.SysMLTypeCheck3;
+import de.monticore.lang.sysmlv2.types3.SysMLTypeVisitorOperatorCalculator;
+import de.monticore.lang.sysmlv2.types3.SysMLWithinScopeBasicSymbolResolver;
+import de.monticore.literals.mccommonliterals.types3.MCCommonLiteralsTypeVisitor;
+import de.monticore.types.check.SymTypeExpression;
+import de.monticore.types.mccollectiontypes.types3.MCCollectionSymTypeRelations;
+import de.monticore.types.mccollectiontypes.types3.MCCollectionTypesTypeVisitor;
+import de.monticore.types3.SymTypeRelations;
+import de.monticore.types3.Type4Ast;
+import de.monticore.types3.TypeCheck3;
+import de.monticore.types3.streams.StreamSymTypeRelations;
+import de.se_rwth.commons.logging.Log;
+import de.se_rwth.commons.logging.LogStub;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CompareTypesTest {
+
+  private final SysMLv2Parser parser = new SysMLv2Parser();
+  private final SysMLv2Tool tool = new SysMLv2Tool();
+
+  @BeforeAll
+  public static void setup() {
+    LogStub.init();
+    SysMLv2Mill.init();
+  }
+
+  @BeforeEach
+  public void clear() {
+    Log.clearFindings();
+    tool.init();
+
+    var type4Ast = new Type4Ast();
+    var typeTraverser = SysMLv2Mill.inheritanceTraverser();
+
+    var forBasis = new ExpressionBasisTypeVisitor();
+    forBasis.setType4Ast(type4Ast);
+    typeTraverser.add4ExpressionsBasis(forBasis);
+
+    var forLiterals = new MCCommonLiteralsTypeVisitor();
+    forLiterals.setType4Ast(type4Ast);
+    typeTraverser.add4MCCommonLiterals(forLiterals);
+
+    var forCommon = new SysMLCommonExpressionsTypeVisitor();
+    forCommon.setType4Ast(type4Ast);
+    typeTraverser.add4CommonExpressions(forCommon);
+    typeTraverser.setCommonExpressionsHandler(forCommon);
+    typeTraverser.add4SysMLExpressions(forCommon);
+    typeTraverser.setSysMLExpressionsHandler(forCommon);
+
+    var forOcl = new SysMLOCLExpressionsTypeVisitor();
+    forOcl.setType4Ast(type4Ast);
+    typeTraverser.add4OCLExpressions(forOcl);
+    typeTraverser.add4SysMLExpressions(forOcl);
+
+    var forStreams = new StreamExpressionsTypeVisitor();
+    forStreams.setType4Ast(type4Ast);
+    typeTraverser.add4StreamExpressions(forStreams);
+
+    var forSets = new SysMLSetExpressionsTypeVisitor();
+    forSets.setType4Ast(type4Ast);
+    typeTraverser.add4SetExpressions(forSets);
+
+    var forBasicTypes = new SysMLMCBasicTypesTypeVisitor();
+    forBasicTypes.setType4Ast(type4Ast);
+    typeTraverser.add4MCBasicTypes(forBasicTypes);
+    typeTraverser.add4SysMLExpressions(forBasicTypes);
+
+    var forCollectionTypes = new MCCollectionTypesTypeVisitor();
+    forCollectionTypes.setType4Ast(type4Ast);
+    typeTraverser.add4MCCollectionTypes(forCollectionTypes);
+
+    StreamSymTypeRelations.init();
+    SysMLWithinScopeBasicSymbolResolver.init();
+    SysMLTypeVisitorOperatorCalculator.init();
+    CommonExpressionsLValueRelations.init();
+    MCCollectionSymTypeRelations.init();
+    SysMLSymTypeRelations.init();
+
+    new SysMLTypeCheck3(typeTraverser, type4Ast).setThisAsDelegate();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "attribute target : boolean; attribute source : ScalarValues::Boolean;"
+  })
+  public void test4CompatibleTypes(String targetAndSource) throws IOException {
+    var type = typeOfConstraintExpression(targetAndSource);
+
+    assertTrue(type.isPrimitive());
+    assertThat(type.printFullName()).isEqualTo("boolean");
+    assertTrue(Log.getFindings().isEmpty());
+  }
+
+  // int und ScalarValues::Integer sollte erlaubt sein, aber das muss noch implementiert werden
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "attribute target : int; attribute source : ScalarValues::Integer;"
+  })
+  public void test4IncompatibleTypes(String targetAndSource) throws IOException {
+    var type = typeOfConstraintExpression(targetAndSource);
+
+    assertTrue(type.isObscureType());
+    assertFalse(Log.getFindings().isEmpty());
+  }
+
+  protected de.monticore.types.check.SymTypeExpression typeOfConstraintExpression(
+      String targetAndSource) throws IOException {
+    var model =
+        "private import ScalarValues::Boolean;" +
+        "part def myPart { " +
+          targetAndSource +
+          "assert constraint e {" +
+            "target == source" +
+          "}" +
+        "}"
+        ;
+
+    var ast = parser.parse_String(model);
+
+    assertThat(ast).isPresent();
+    assertThat(Log.getFindings()).isEmpty();
+
+    var astSysMLModel = ast.get();
+    tool.createSymbolTable(astSysMLModel);
+    tool.completeSymbolTable(astSysMLModel);
+    tool.finalizeSymbolTable(astSysMLModel);
+
+    var sysmlelements = astSysMLModel.getSysMLElementList();
+    var astPartDef = sysmlelements.get(1);
+    var constraintUsage = ((ASTPartDef) astPartDef).getSysMLElement(2);
+    var expr = ((ASTConstraintUsage) constraintUsage).getExpression();
+
+    return TypeCheck3.typeOf(expr);
+  }
+}


### PR DESCRIPTION
## Changed

- Füge einen neuen Resolver hinzu, welcher java.lang Symbole lädt. Diese werden zum Boxen primitiver Typen benötigt. Zum Beispiel: 
`boolean -> java.lang.Boolean`