### PR TITLE
7.8.84: Compatibility between ScalarValues.Integer and MC-int

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,4 +25,4 @@ assertj_version    = 3.21.0
 junit_version      = 5.8.2
 
 # Version of published artifacts
-version            = 7.8.83
+version            = 7.8.84

--- a/language/src/main/java/de/monticore/lang/sysmlv2/types3/SysMLBuiltInTypeRelations.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/types3/SysMLBuiltInTypeRelations.java
@@ -2,32 +2,30 @@ package de.monticore.lang.sysmlv2.types3;
 
 import de.monticore.types.check.SymTypeExpression;
 
-
+/**
+ * Dient dazu die MontiCore Built-Ins (int, String, boolean, nat) mit den
+ * KerML-ScalarValues (Integer, String, Boolean, Natural/Positive) kompatibel
+ * zu machen.
+ */
 public class SysMLBuiltInTypeRelations extends de.monticore.types3.util.BuiltInTypeRelations{
 
   @Override
   public boolean isIntegralType(SymTypeExpression type) {
-    return super.isIntegralType(type) ||
-      isNat(type) ||
-      checkFullName(type, "ScalarValues.Integer");
+    return super.isIntegralType(type)
+        || (type.isPrimitive()
+          && type.asPrimitive().getPrimitiveName().equals("nat"))
+        || (type.hasTypeInfo()
+          && (
+            type.getTypeInfo().getFullName().equals("ScalarValues.Integer") ||
+            type.getTypeInfo().getFullName().equals("ScalarValues.Natural") ||
+            type.getTypeInfo().getFullName().equals("ScalarValues.Positive"))
+    );
   }
 
   @Override
   public boolean isBoolean(SymTypeExpression type) {
-    return super.isBoolean(type) || checkFullName(type, "ScalarValues.Boolean");
-  }
-
-  public boolean isNat(SymTypeExpression type) {
-    return (
-      type.isPrimitive() &&
-      type.asPrimitive().getPrimitiveName().equals("nat")
-    ) ||
-      checkFullName(type, "ScalarValues.Natural") ||
-      checkFullName(type, "ScalarValues.Positive");
-  }
-
-  private boolean checkFullName(SymTypeExpression type, String fullName) {
-    return type.hasTypeInfo() &&
-      type.getTypeInfo().getFullName().equals(fullName);
+    return super.isBoolean(type) ||
+      (type.hasTypeInfo() &&
+        type.getTypeInfo().getFullName().equals("ScalarValues.Boolean"));
   }
 }

--- a/language/src/main/java/de/monticore/lang/sysmlv2/types3/SysMLBuiltInTypeRelations.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/types3/SysMLBuiltInTypeRelations.java
@@ -1,0 +1,33 @@
+package de.monticore.lang.sysmlv2.types3;
+
+import de.monticore.types.check.SymTypeExpression;
+
+
+public class SysMLBuiltInTypeRelations extends de.monticore.types3.util.BuiltInTypeRelations{
+
+  @Override
+  public boolean isIntegralType(SymTypeExpression type) {
+    return super.isIntegralType(type) ||
+      isNat(type) ||
+      checkFullName(type, "ScalarValues.Integer");
+  }
+
+  @Override
+  public boolean isBoolean(SymTypeExpression type) {
+    return super.isBoolean(type) || checkFullName(type, "ScalarValues.Boolean");
+  }
+
+  public boolean isNat(SymTypeExpression type) {
+    return (
+      type.isPrimitive() &&
+      type.asPrimitive().getPrimitiveName().equals("nat")
+    ) ||
+      checkFullName(type, "ScalarValues.Natural") ||
+      checkFullName(type, "ScalarValues.Positive");
+  }
+
+  private boolean checkFullName(SymTypeExpression type, String fullName) {
+    return type.hasTypeInfo() &&
+      type.getTypeInfo().getFullName().equals(fullName);
+  }
+}

--- a/language/src/main/java/de/monticore/lang/sysmlv2/types3/SysMLSymTypeRelations.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/types3/SysMLSymTypeRelations.java
@@ -1,9 +1,6 @@
 package de.monticore.lang.sysmlv2.types3;
 
 import de.monticore.ocl.types3.OCLSymTypeRelations;
-import de.monticore.types.check.SymTypeExpression;
-import de.monticore.types3.util.BuiltInTypeRelations;
-import de.monticore.types3.util.SymTypeCompatibilityCalculator;
 import de.monticore.types3.util.SymTypeRelationsDefaultDelegatee;
 
 public abstract class SysMLSymTypeRelations extends OCLSymTypeRelations {
@@ -16,28 +13,7 @@ public abstract class SysMLSymTypeRelations extends OCLSymTypeRelations {
   protected static class SysMLSymTypeRelationsDelegatee extends
       SymTypeRelationsDefaultDelegatee {
     public SysMLSymTypeRelationsDelegatee() {
-      builtInRelationsDelegate = new BuiltInTypeRelations() {
-        @Override
-        public boolean isIntegralType(SymTypeExpression type) {
-          return super.isIntegralType(type) ||
-              type.isPrimitive() &&
-                  type.asPrimitive().getPrimitiveName().equals("nat");
-        }
-
-        /*
-        Any Type that is included here will be compatible with any other Type
-        in the list.
-         */
-        @Override
-        public boolean isBoolean(SymTypeExpression type) {
-          return (super.isBoolean(type) ||
-            (
-              type.hasTypeInfo() &&
-              type.getTypeInfo().getFullName().equals("ScalarValues.Boolean")
-            )
-          );
-        }
-      };
+      builtInRelationsDelegate = new SysMLBuiltInTypeRelations();
     }
   }
 }

--- a/language/src/test/java/typecheck/CompareTypesTest.java
+++ b/language/src/test/java/typecheck/CompareTypesTest.java
@@ -57,7 +57,8 @@ public class CompareTypesTest {
 
   @ParameterizedTest
   @ValueSource(strings = {
-      "attribute target : boolean; attribute source : ScalarValues::Boolean;"
+      "attribute target : boolean; attribute source : ScalarValues::Boolean;",
+      "attribute target : ScalarValues::Integer; attribute source : int;",
   })
   public void test4CompatibleTypes(String targetAndSource) throws IOException {
     var type = typeOfConstraintExpression(targetAndSource);
@@ -70,7 +71,7 @@ public class CompareTypesTest {
   // int und ScalarValues::Integer sollte erlaubt sein, aber das muss noch implementiert werden
   @ParameterizedTest
   @ValueSource(strings = {
-      "attribute target : int; attribute source : ScalarValues::Integer;"
+      "attribute target : int; attribute source : ScalarValues::String;"
   })
   public void test4IncompatibleTypes(String targetAndSource) throws IOException {
     var type = typeOfConstraintExpression(targetAndSource);


### PR DESCRIPTION
## Changed

- Neue SysMLBuiltInTypeRelations Klasse um zukünftige Erweiterungen zu vereinfachen
- 'ScalarValues.Integer' sind nun kompatibel mit 'int'

Der CompatibilityCalculator betrachten die linke und rechte Seite und macht nur weiter wenn beide Primitive- oder Obejekt-Typen sind. Im Verlauf versucht er beide zu boxen. Dabei ist aber  'int' zu 'java.lang.Integer' gescheitert, da es die Symbole nicht gab.

7.8.81: Load java.lang TypeSymbols hat es möglich gemacht 'int' zu 'java.lang.Integer' zu boxen, wodurch jetzt links und rechts 2 Objekt-Typen stehen.

Das erlaubt dem Calculator nun zu fragen, ob beide Objekte Integral Types sind. In dieser PR wird nun 'ScalarValues.Integer' als Integral-Type angesehen.