### PR TITLE
#402 Ports und Attribute einer Connection in Parent Komponente finden

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,4 +25,4 @@ assertj_version    = 3.21.0
 junit_version      = 5.8.2
 
 # Version of published artifacts
-version            = 7.8.84
+version            = 7.8.85

--- a/language/src/main/java/de/monticore/lang/sysmlv2/cocos/QualifiedPortNameExistsCoCo.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/cocos/QualifiedPortNameExistsCoCo.java
@@ -10,7 +10,6 @@ import de.monticore.lang.sysmlparts._symboltable.PartUsageSymbol;
 import de.monticore.symboltable.modifiers.AccessModifier;
 import de.se_rwth.commons.logging.Log;
 
-import java.util.List;
 import java.util.Optional;
 
 /**
@@ -76,8 +75,7 @@ public class QualifiedPortNameExistsCoCo implements SysMLPartsASTConnectionUsage
     else {
       // Unqualifiziert: Port der Oberkomponente muss lokal existieren
       String portName = parts[0];
-      List<?> localPorts = scope.resolvePortUsageLocallyMany(
-          false, portName, AccessModifier.ALL_INCLUSION, p -> true);
+      Optional<?> localPorts = scope.resolveVariable(portName);
       if (localPorts.isEmpty()) {
         Log.error(
             "0x10AA4 The port used in 'connect' '" + portName


### PR DESCRIPTION
## Changelog <!-- See https://keepachangelog.com/en/1.1.0/ -->

##### Changed <!-- for new features -->

* Die Connection-CoCo `QualifiedPortNamesExist` prüft die Existenz der Enden nicht mehr mit einem spezifischen `resolvePortUsage`, sondern einem allgemeineren `resolveVariable`. Dadurch können auch Attribute-Usages gefunden werden (Symboladapter ex. bereits). Alle Adapter vorausgesetzt, nähert sich das Vorgehen dem SysML-Standard an, da Connections beleibige Modellelemente verbinden können. Für uns besonders relevant: Die Verbindung von Stream-getypten Attribute-Usages und Port-Usages.

