### PR TITLE
7.8.86: numerische Typen aus ScalarValues werden als solche erkannt

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,4 +25,4 @@ assertj_version    = 3.21.0
 junit_version      = 5.8.2
 
 # Version of published artifacts
-version            = 7.8.85
+version            = 7.8.86

--- a/language/src/main/java/de/monticore/lang/sysmlv2/types3/SysMLBuiltInTypeRelations.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/types3/SysMLBuiltInTypeRelations.java
@@ -38,4 +38,14 @@ public class SysMLBuiltInTypeRelations extends de.monticore.types3.util.BuiltInT
       (type.hasTypeInfo() &&
         type.getTypeInfo().getFullName().equals("ScalarValues.Boolean"));
   }
+
+  @Override
+  public boolean isDouble(SymTypeExpression type) {
+    return super.isDouble(type)
+      || (type.hasTypeInfo() && (
+        type.getTypeInfo().getFullName().equals("ScalarValues.Real") ||
+        type.getTypeInfo().getFullName().equals("ScalarValues.Rational"))
+    );
+  }
+
 }

--- a/language/src/main/java/de/monticore/lang/sysmlv2/types3/SysMLBuiltInTypeRelations.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/types3/SysMLBuiltInTypeRelations.java
@@ -48,4 +48,13 @@ public class SysMLBuiltInTypeRelations extends de.monticore.types3.util.BuiltInT
     );
   }
 
+  @Override
+  public boolean isInt(SymTypeExpression type) {
+    return super.isInt(type)
+      || (type.isPrimitive()
+        && type.asPrimitive().getPrimitiveName().equals("nat"))
+      || (type.hasTypeInfo()
+        && type.getTypeInfo().getFullName().equals("ScalarValues.Natural"));
+  }
+
 }

--- a/language/src/main/java/de/monticore/lang/sysmlv2/types3/SysMLBuiltInTypeRelations.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/types3/SysMLBuiltInTypeRelations.java
@@ -48,8 +48,10 @@ public class SysMLBuiltInTypeRelations extends de.monticore.types3.util.BuiltInT
     return super.isInt(type)
       || (type.isPrimitive()
         && type.asPrimitive().getPrimitiveName().equals("nat"))
-      || (type.hasTypeInfo()
-        && type.getTypeInfo().getFullName().equals("ScalarValues.Natural"));
+      || (type.hasTypeInfo() && (
+        type.getTypeInfo().getFullName().equals("ScalarValues.Natural") ||
+        type.getTypeInfo().getFullName().equals("ScalarValues.Positive"))
+    );
   }
 
   @Override

--- a/language/src/main/java/de/monticore/lang/sysmlv2/types3/SysMLBuiltInTypeRelations.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/types3/SysMLBuiltInTypeRelations.java
@@ -57,4 +57,13 @@ public class SysMLBuiltInTypeRelations extends de.monticore.types3.util.BuiltInT
         && type.getTypeInfo().getFullName().equals("ScalarValues.Natural"));
   }
 
+  @Override
+  public boolean isString(SymTypeExpression type) {
+    boolean isScalarValuesString = false;
+    if (type.isObjectType()) {
+      isScalarValuesString = type.hasTypeInfo()
+        && (type.getTypeInfo().getFullName().equals("ScalarValues.String"));
+    }
+    return super.isString(type) || isScalarValuesString;
+  }
 }

--- a/language/src/main/java/de/monticore/lang/sysmlv2/types3/SysMLBuiltInTypeRelations.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/types3/SysMLBuiltInTypeRelations.java
@@ -11,12 +11,7 @@ public class SysMLBuiltInTypeRelations extends de.monticore.types3.util.BuiltInT
 
   @Override
   public boolean isNumericType(SymTypeExpression type) {
-    return super.isNumericType(type) || isIntegralType(type)
-      || (type.hasTypeInfo()
-        && (
-          type.getTypeInfo().getFullName().equals("ScalarValues.Real") ||
-          type.getTypeInfo().getFullName().equals("ScalarValues.Rational"))
-    );
+    return super.isNumericType(type) || isIntegralType(type) || isDouble(type);
   }
 
   @Override

--- a/language/src/main/java/de/monticore/lang/sysmlv2/types3/SysMLBuiltInTypeRelations.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/types3/SysMLBuiltInTypeRelations.java
@@ -10,6 +10,16 @@ import de.monticore.types.check.SymTypeExpression;
 public class SysMLBuiltInTypeRelations extends de.monticore.types3.util.BuiltInTypeRelations{
 
   @Override
+  public boolean isNumericType(SymTypeExpression type) {
+    return super.isNumericType(type) || isIntegralType(type)
+      || (type.hasTypeInfo()
+        && (
+          type.getTypeInfo().getFullName().equals("ScalarValues.Real") ||
+          type.getTypeInfo().getFullName().equals("ScalarValues.Rational"))
+    );
+  }
+
+  @Override
   public boolean isIntegralType(SymTypeExpression type) {
     return super.isIntegralType(type)
         || (type.isPrimitive()

--- a/language/src/test/java/typecheck/CompareTypesTest.java
+++ b/language/src/test/java/typecheck/CompareTypesTest.java
@@ -1,30 +1,11 @@
 package typecheck;
 
-import de.monticore.expressions.commonexpressions.types3.util.CommonExpressionsLValueRelations;
-import de.monticore.expressions.expressionsbasis.types3.ExpressionBasisTypeVisitor;
-import de.monticore.expressions.streamexpressions.types3.StreamExpressionsTypeVisitor;
 import de.monticore.lang.sysmlconstraints._ast.ASTConstraintUsage;
 import de.monticore.lang.sysmlparts._ast.ASTPartDef;
-import de.monticore.lang.sysmlparts._ast.ASTPartUsage;
 import de.monticore.lang.sysmlv2.SysMLv2Mill;
 import de.monticore.lang.sysmlv2.SysMLv2Tool;
 import de.monticore.lang.sysmlv2._parser.SysMLv2Parser;
-import de.monticore.lang.sysmlv2.types3.SysMLCommonExpressionsTypeVisitor;
-import de.monticore.lang.sysmlv2.types3.SysMLMCBasicTypesTypeVisitor;
-import de.monticore.lang.sysmlv2.types3.SysMLOCLExpressionsTypeVisitor;
-import de.monticore.lang.sysmlv2.types3.SysMLSetExpressionsTypeVisitor;
-import de.monticore.lang.sysmlv2.types3.SysMLSymTypeRelations;
-import de.monticore.lang.sysmlv2.types3.SysMLTypeCheck3;
-import de.monticore.lang.sysmlv2.types3.SysMLTypeVisitorOperatorCalculator;
-import de.monticore.lang.sysmlv2.types3.SysMLWithinScopeBasicSymbolResolver;
-import de.monticore.literals.mccommonliterals.types3.MCCommonLiteralsTypeVisitor;
-import de.monticore.types.check.SymTypeExpression;
-import de.monticore.types.mccollectiontypes.types3.MCCollectionSymTypeRelations;
-import de.monticore.types.mccollectiontypes.types3.MCCollectionTypesTypeVisitor;
-import de.monticore.types3.SymTypeRelations;
-import de.monticore.types3.Type4Ast;
 import de.monticore.types3.TypeCheck3;
-import de.monticore.types3.streams.StreamSymTypeRelations;
 import de.se_rwth.commons.logging.Log;
 import de.se_rwth.commons.logging.LogStub;
 import org.junit.jupiter.api.BeforeAll;
@@ -55,10 +36,27 @@ public class CompareTypesTest {
     tool.init();
   }
 
+  /*
+   * String und nat benötigen boxing, da es für nat keinen java.lang.Natural gibt.
+   * Für String gilt, Objekte-Kompatibel, wenn eine der Bedingungen erfüllt ist:
+   * - den gleichen Namen und die gleichen Args haben
+   * - Super/Sub-types voneinander sein
+   * - zu den gleichen Typen oder zu Super/Sub-types voneinander geboxed werden
+   */
   @ParameterizedTest
   @ValueSource(strings = {
       "attribute target : boolean; attribute source : ScalarValues::Boolean;",
+      "attribute target : int; attribute source : ScalarValues::Rational;",
+      "attribute target : float; attribute source : ScalarValues::Real;",
+      "attribute target : ScalarValues::Natural; attribute source : ScalarValues::Real;",
+      "attribute target : ScalarValues::Integer; attribute source : ScalarValues::Rational;",
       "attribute target : ScalarValues::Integer; attribute source : int;",
+      "attribute target : ScalarValues::Integer; attribute source : ScalarValues::Natural;",
+      "attribute target : double; attribute source : ScalarValues::Real;",
+      "attribute target : int; attribute source : ScalarValues::Positive;",
+      "attribute target : ScalarValues::Positive; attribute source : ScalarValues::Natural;",
+//      "attribute target : ScalarValues::String; attribute source : String;",
+//      "attribute target : ScalarValues::Natural; attribute source : nat;"
   })
   public void test4CompatibleTypes(String targetAndSource) throws IOException {
     var type = typeOfConstraintExpression(targetAndSource);


### PR DESCRIPTION
## Changed

- Überschreibe BuiltinTypeRelations, spezifisch `isNumericType` und die spezielleren `isDouble`, ..., `inInt` damit numerische Typen aus ScalarValues als solche erkannt werden
  * Nötig für den Typecheck von Numerischen Typen: Diese werden speziell behandelt, wenn links und rechts (nach evtl. Boxing) ein numerischer Typ steht, dann werden diese gesondert auf Kompatibilität geprüft. Zb. ist erlaubt einen Integer einem Float zuzuweisen.
  * Nach diesem PR erlaubt es der TypeChecker also, dass eine Zuweisung oder ein Vergleich zwischen MontiCore's Builtins (int, float & Co.) und numerischen ScalarValues-Typen möglich ist
  * Limitationen:
    - `nat` hat keine geboxte Fassung im Stanard-Boxing, weil Java keine natürlichen Zahlen kennt.
    - Strings sind nicht numerisch und werden als Objekte Namensweise verglichen. Der Fix ist ausstehend.