### PR TITLE
7.8.87: MC-Type nat zu ScalarValues::Natural boxen

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,4 +25,4 @@ assertj_version    = 3.21.0
 junit_version      = 5.8.2
 
 # Version of published artifacts
-version            = 7.8.86
+version            = 7.8.87

--- a/language/src/main/java/de/monticore/lang/sysmlv2/types3/SysMLSymTypeRelations.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/types3/SysMLSymTypeRelations.java
@@ -1,5 +1,6 @@
 package de.monticore.lang.sysmlv2.types3;
 
+import de.monticore.lang.sysmlv2.types3.util.SysMLSymTypeBoxingVisitor;
 import de.monticore.ocl.types3.OCLSymTypeRelations;
 import de.monticore.types3.util.SymTypeRelationsDefaultDelegatee;
 
@@ -14,6 +15,7 @@ public abstract class SysMLSymTypeRelations extends OCLSymTypeRelations {
       SymTypeRelationsDefaultDelegatee {
     public SysMLSymTypeRelationsDelegatee() {
       builtInRelationsDelegate = new SysMLBuiltInTypeRelations();
+      boxingVisitor = new SysMLSymTypeBoxingVisitor();
     }
   }
 }

--- a/language/src/main/java/de/monticore/lang/sysmlv2/types3/SysMLSymTypeRelations.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/types3/SysMLSymTypeRelations.java
@@ -1,6 +1,7 @@
 package de.monticore.lang.sysmlv2.types3;
 
 import de.monticore.lang.sysmlv2.types3.util.SysMLSymTypeBoxingVisitor;
+import de.monticore.lang.sysmlv2.types3.util.SysMLSymTypeCompatibilityCalculator;
 import de.monticore.ocl.types3.OCLSymTypeRelations;
 import de.monticore.types3.util.SymTypeRelationsDefaultDelegatee;
 
@@ -16,6 +17,7 @@ public abstract class SysMLSymTypeRelations extends OCLSymTypeRelations {
     public SysMLSymTypeRelationsDelegatee() {
       builtInRelationsDelegate = new SysMLBuiltInTypeRelations();
       boxingVisitor = new SysMLSymTypeBoxingVisitor();
+      compatibilityDelegate = new SysMLSymTypeCompatibilityCalculator();
     }
   }
 }

--- a/language/src/main/java/de/monticore/lang/sysmlv2/types3/util/SysMLSymTypeBoxingVisitor.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/types3/util/SysMLSymTypeBoxingVisitor.java
@@ -1,0 +1,30 @@
+package de.monticore.lang.sysmlv2.types3.util;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class SysMLSymTypeBoxingVisitor extends de.monticore.types3.util.SymTypeBoxingVisitor {
+
+  protected static final Map<String, String> sysMLPrimitiveBoxMap;
+  protected static final Map<String, String> sysMLObjectBoxMap;
+
+  static {
+    Map<String, String> primitiveBoxMap_temp = new HashMap<>(primitiveBoxMap);
+    primitiveBoxMap_temp.put("nat", "ScalarValues.Natural");
+    sysMLPrimitiveBoxMap = Collections.unmodifiableMap(primitiveBoxMap_temp);
+
+    Map<String, String> objectBoxMap_temp = new HashMap<>(objectBoxMap);
+    sysMLObjectBoxMap = Collections.unmodifiableMap(objectBoxMap_temp);
+  }
+
+  @Override
+  public Map<String, String> getPrimitiveBoxMap() {
+    return sysMLPrimitiveBoxMap;
+  }
+
+  @Override
+  public Map<String, String> getObjectBoxMap() {
+    return sysMLObjectBoxMap;
+  }
+}

--- a/language/src/main/java/de/monticore/lang/sysmlv2/types3/util/SysMLSymTypeCompatibilityCalculator.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/types3/util/SysMLSymTypeCompatibilityCalculator.java
@@ -1,0 +1,55 @@
+package de.monticore.lang.sysmlv2.types3.util;
+
+import de.monticore.types.check.SymTypeExpression;
+import de.monticore.types3.generics.bounds.Bound;
+
+import java.util.Collections;
+import java.util.List;
+
+public class SysMLSymTypeCompatibilityCalculator extends de.monticore.types3.util.SymTypeCompatibilityCalculator{
+
+  @Override
+  protected List<Bound> constrainCompatiblePreNormalized(
+      SymTypeExpression target,
+      SymTypeExpression source
+  ) {
+    List<Bound> result;
+    if (target.isTypeVariable() ||
+        target.isInferenceVariable() ||
+        target.isWildcard() ||
+        source.isTypeVariable() ||
+        source.isInferenceVariable() ||
+        source.isWildcard()
+    ) {
+      result = typeSetConstrainCompatible(target, source);
+    }
+    else if (source.deepEquals(target)) {
+      result = Collections.emptyList();
+    }
+    else if (source.isNullType()) {
+      result = nullConstrainCompatible(target, source.asNullType());
+    }
+    else {
+      // Die einzige Änderung ist die hier die verwendete SymTypeRelations
+      SymTypeExpression boxedTarget = de.monticore.lang.sysmlv2.types3.SysMLSymTypeRelations.box(target);
+      SymTypeExpression boxedSource = de.monticore.lang.sysmlv2.types3.SysMLSymTypeRelations.box(source);
+
+      result = constrainSubTypeOf(source, target);
+      if (result.stream().anyMatch(Bound::isUnsatisfiableBound)) {
+        result = constrainSubTypeOf(boxedSource, target);
+      }
+      if (result.stream().anyMatch(Bound::isUnsatisfiableBound)) {
+        result = constrainSubTypeOf(source, boxedTarget);
+      }
+      if (result.stream().anyMatch(Bound::isUnsatisfiableBound)) {
+        result = constrainSubTypeOf(boxedSource, boxedTarget);
+      }
+    }
+    if (result.stream().anyMatch(Bound::isUnsatisfiableBound)) {
+      if (target.isRegExType() || source.isRegExType()) {
+        result = regExConstrainCompatible(target, source);
+      }
+    }
+    return result;
+  }
+}

--- a/language/src/test/java/typecheck/CompareTypesTest.java
+++ b/language/src/test/java/typecheck/CompareTypesTest.java
@@ -56,7 +56,7 @@ public class CompareTypesTest {
       "attribute target : int; attribute source : ScalarValues::Positive;",
       "attribute target : ScalarValues::Positive; attribute source : ScalarValues::Natural;",
 //      "attribute target : ScalarValues::String; attribute source : String;",
-//      "attribute target : ScalarValues::Natural; attribute source : nat;"
+      "attribute target : ScalarValues::Natural; attribute source : nat;"
   })
   public void test4CompatibleTypes(String targetAndSource) throws IOException {
     var type = typeOfConstraintExpression(targetAndSource);


### PR DESCRIPTION
## Changed

- Überschreibe SymTypeBoxingVisitor, spezifisch die `primitiveBoxMap` um den primitiven Typen `nat` nach ObjektTyp `ScalarValues.Natural` zu boxen
  * Nötig für den Typecheck zwischen numerischen primitiven und Objekt Typen: Nur wenn links und rechts (nach evtl. Boxing) beide primitive oder Objekt Typen sind, dann werden diese auf Kompatibilität geprüft. MC-Typ `nat` hatte kein boxing auf einen Objekt Typ, da es kein äquivalentes Java.lang-Symbol gab. Dies führte dazu, dass 'nat' mit keinem Numerischen Objekt Typ kompatibel war
