### PR TITLE
Endpoint aus Basis nach Parts verschoben

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,4 +25,4 @@ assertj_version    = 3.21.0
 junit_version      = 5.8.2
 
 # Version of published artifacts
-version            = 7.8.87
+version            = 7.8.88

--- a/language/src/main/grammars/de/monticore/lang/SysMLBasis.mc4
+++ b/language/src/main/grammars/de/monticore/lang/SysMLBasis.mc4
@@ -158,8 +158,4 @@ component grammar SysMLBasis
   // Inline-Variante für das "first" vor dem "then"
   interface IInlineOccurrenceUsage ;
 
-  // Used regularly in successions
-  Endpoint =
-    MCQualifiedName SysMLCardinality? Specialization* ;
-
 }

--- a/language/src/main/grammars/de/monticore/lang/SysMLParts.mc4
+++ b/language/src/main/grammars/de/monticore/lang/SysMLParts.mc4
@@ -600,4 +600,8 @@ component grammar SysMLParts extends SysMLBasis {
         SysMLElement*
       "}" | ";") ;
 
+    // Used regularly in successions
+      Endpoint =
+        MCQualifiedName SysMLCardinality? Specialization* ;
+
 }

--- a/language/src/main/java/de/monticore/lang/sysmlv2/cocos/QualifiedPortNameExistsCoCo.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/cocos/QualifiedPortNameExistsCoCo.java
@@ -1,7 +1,7 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.lang.sysmlv2.cocos;
 
-import de.monticore.lang.sysmlbasis._ast.ASTEndpoint;
+import de.monticore.lang.sysmlparts._ast.ASTEndpoint;
 import de.monticore.lang.sysmlparts._ast.ASTConnectionUsage;
 import de.monticore.lang.sysmlparts._cocos.SysMLPartsASTConnectionUsageCoCo;
 import de.monticore.lang.sysmlparts._symboltable.ISysMLPartsScope;

--- a/language/src/main/java/de/monticore/lang/sysmlv2/cocos/SubPartNamesInConnectionExistCoCo.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/cocos/SubPartNamesInConnectionExistCoCo.java
@@ -1,7 +1,7 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.lang.sysmlv2.cocos;
 
-import de.monticore.lang.sysmlbasis._ast.ASTEndpoint;
+import de.monticore.lang.sysmlparts._ast.ASTEndpoint;
 import de.monticore.lang.sysmlparts._ast.ASTConnectionUsage;
 import de.monticore.lang.sysmlparts._cocos.SysMLPartsASTConnectionUsageCoCo;
 import de.monticore.lang.sysmlparts._symboltable.ISysMLPartsScope;

--- a/language/src/main/java/de/monticore/lang/sysmlv2/cocos/SubcomponentOutputConnectionDirectionCoCo.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/cocos/SubcomponentOutputConnectionDirectionCoCo.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.lang.sysmlv2.cocos;
 
-import de.monticore.lang.sysmlbasis._ast.ASTEndpoint;
 import de.monticore.lang.sysmlbasis._ast.ASTSysMLTyping;
+import de.monticore.lang.sysmlparts._ast.ASTEndpoint;
 import de.monticore.lang.sysmlparts._ast.ASTAttributeUsage;
 import de.monticore.lang.sysmlparts._ast.ASTConnectionUsage;
 import de.monticore.lang.sysmlparts._cocos.SysMLPartsASTConnectionUsageCoCo;


### PR DESCRIPTION
### Changed 

- Endpoint wurde von SysMLBasis.mc4 nach SysMLParts.mc4 verschoben
- Importe wurden angepasst


### Zeitliche Verbesserung (in ms)

Vorher Average : 5742,1235
Nachher Average : 5693,626967

Verbesserung ~0,8%

Verbesserung jedoch nicht so aussagekräftig, da mehrere Durchläufe auch langsamer waren. Also eher neutrale Verbesserung