### PR TITLE
Modifier von SysMLParameter entfernt

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,4 +25,4 @@ assertj_version    = 3.21.0
 junit_version      = 5.8.2
 
 # Version of published artifacts
-version            = 7.8.89
+version            = 7.8.90

--- a/language/src/main/grammars/de/monticore/lang/SysMLBasis.mc4
+++ b/language/src/main/grammars/de/monticore/lang/SysMLBasis.mc4
@@ -72,7 +72,7 @@ component grammar SysMLBasis
    * Parameters
    */
   SysMLParameter implements Field =
-    Modifier UserDefinedKeyword* ["stream"]? Name SysMLCardinality? Specialization* ("=" binding:Expression)? DefaultValue?;
+    UserDefinedKeyword* ["stream"]? Name SysMLCardinality? Specialization* ("=" binding:Expression)? DefaultValue?;
 
   /**
    * A fixed, bound feature value relationship is declared using the symbol = followed by a representation of the value

--- a/language/src/test/java/symboltable/SerializationTest.java
+++ b/language/src/test/java/symboltable/SerializationTest.java
@@ -13,6 +13,7 @@ import de.monticore.lang.sysmlv2._symboltable.ISysMLv2Scope;
 import de.monticore.symboltable.serialization.JsonPrinter;
 import org.apache.commons.io.FileUtils;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -84,6 +85,11 @@ public class SerializationTest {
   @BeforeAll
   public static void setPrinter() {
     JsonPrinter.enableIndentation();
+  }
+
+  @AfterAll
+  public static void resetPrinter() {
+    JsonPrinter.disableIndentation();
   }
 
   @BeforeEach

--- a/language/src/test/resources/symboltable/serialization/exhibitState/StateDef.sym
+++ b/language/src/test/resources/symboltable/serialization/exhibitState/StateDef.sym
@@ -15,6 +15,30 @@
             "spannedScope": {
               "symbols": [
                 {
+                  "kind": "de.monticore.lang.sysmlparts._symboltable.AttributeUsageSymbol",
+                  "name": "i",
+                  "fullName":"StateDef.AutomatonInverter.i",
+                  "types": [
+                    {
+                      "kind": "de.monticore.types.check.SymTypePrimitive",
+                      "primitiveName": "boolean"
+                    }
+                  ],
+                  "in": true
+                },
+                {
+                  "kind": "de.monticore.lang.sysmlparts._symboltable.AttributeUsageSymbol",
+                  "name": "o",
+                  "fullName":"StateDef.AutomatonInverter.o",
+                  "types": [
+                    {
+                      "kind": "de.monticore.types.check.SymTypePrimitive",
+                      "primitiveName": "boolean"
+                    }
+                  ],
+                  "out": true
+                },
+                {
                   "kind": "de.monticore.lang.sysmlstates._symboltable.StateUsageSymbol",
                   "name": "S",
                   "fullName":"StateDef.AutomatonInverter.S"
@@ -23,24 +47,6 @@
                   "kind": "de.monticore.lang.sysmlstates._symboltable.SysMLTransitionSymbol",
                   "name": "invert",
                   "fullName":"StateDef.AutomatonInverter.invert"
-                },
-                {
-                  "kind": "de.monticore.symbols.oosymbols._symboltable.FieldSymbol",
-                  "name": "i",
-                  "fullName":"StateDef.AutomatonInverter.i",
-                  "type": {
-                    "kind": "de.monticore.types.check.SymTypePrimitive",
-                    "primitiveName": "boolean"
-                  }
-                },
-                {
-                  "kind": "de.monticore.symbols.oosymbols._symboltable.FieldSymbol",
-                  "name": "o",
-                  "fullName":"StateDef.AutomatonInverter.o",
-                  "type": {
-                    "kind": "de.monticore.types.check.SymTypePrimitive",
-                    "primitiveName": "boolean"
-                  }
                 }
               ]
             }

--- a/language/src/test/resources/symboltable/serialization/exhibitState/StateDef.sysml
+++ b/language/src/test/resources/symboltable/serialization/exhibitState/StateDef.sysml
@@ -1,7 +1,11 @@
 /* (c) https://github.com/MontiCore/monticore */
 package StateDef {
 
-  state def AutomatonInverter(in i: boolean, out o: boolean) {
+  state def AutomatonInverter {
+
+    in attribute i : boolean;
+    out attribute o : boolean;
+
     entry;
       then S;
 


### PR DESCRIPTION
### Changed

- `Modifier` wurde wieder aus `SysMLParameter` entfernt.
- `StateDef.sysml` wurde angepasst, sodass `in` und `out` nicht mehr in der Parameterliste stehen, sondern als Attribute im Body. Das ist näher an der Schreibweise, die auch SysIDE akzeptiert.
- Die dazugehörige `StateDef.sym` musste angepasst werden, weil sich durch die Änderung auch die erwartete Symboltabellen-Ausgabe geändert hat.
- In `SerializationTest.java` wurde die Indentation für die `.sym`-Dateien aktiviert, aber danach nicht wieder deaktiviert. Dadurch sind spätere Tests fehlgeschlagen, obwohl der Inhalt eigentlich gleich war. Deshalb wird die Indentation nach dem Test jetzt wieder ausgeschaltet.

