### PR TITLE
7.8.90: Entferne Class2Mc und java.lang Symbole

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,4 +25,4 @@ assertj_version    = 3.21.0
 junit_version      = 5.8.2
 
 # Version of published artifacts
-version            = 7.8.89
+version            = 7.8.90

--- a/language/build.gradle
+++ b/language/build.gradle
@@ -71,7 +71,6 @@ dependencies {
   implementation "de.monticore:monticore-runtime:$mc_version"
   implementation "de.monticore:monticore-grammar:$mc_version"
   implementation "de.monticore:stream-symbols:$mc_version"
-  implementation "de.monticore:class2mc:$mc_version"
   implementation "de.monticore.lang:ocl:$mc_version"
   implementation "commons-cli:commons-cli:$commons_cli_version"
 }

--- a/language/src/main/java/de/monticore/lang/sysmlv2/SysMLv2Mill.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/SysMLv2Mill.java
@@ -2,7 +2,6 @@
 package de.monticore.lang.sysmlv2;
 
 import de.monticore.symbols.basicsymbols.BasicSymbolsMill;
-import de.monticore.class2mc.OOClass2MCResolver;
 import de.monticore.types.check.SymTypeExpression;
 import de.monticore.symbols.basicsymbols._symboltable.FunctionSymbol;
 import de.monticore.symbols.basicsymbols._symboltable.IBasicSymbolsGlobalScope;
@@ -46,11 +45,6 @@ public class SysMLv2Mill extends SysMLv2MillTOP {
     SysMLv2Tool.loadStreamSymbolsFromJar();
   }
 
-  public void initializeClass2MC() {
-    SysMLv2Mill.globalScope().addAdaptedTypeSymbolResolver(new OOClass2MCResolver());
-    SysMLv2Mill.globalScope().addAdaptedOOTypeSymbolResolver(new OOClass2MCResolver());
-  }
-
   protected static void loadScalarValuesFromSym() {
     getMill()._loadScalarValuesFromSym();
   }
@@ -89,7 +83,6 @@ public class SysMLv2Mill extends SysMLv2MillTOP {
   public static void initializePrimitives() {
     BasicSymbolsMill.initializePrimitives();
     getMill()._initializePrimitives();
-    getMill().initializeClass2MC();
   }
 
   /**

--- a/language/src/main/java/de/monticore/lang/sysmlv2/types3/SysMLBuiltInTypeRelations.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/types3/SysMLBuiltInTypeRelations.java
@@ -49,6 +49,7 @@ public class SysMLBuiltInTypeRelations extends de.monticore.types3.util.BuiltInT
       || (type.isPrimitive()
         && type.asPrimitive().getPrimitiveName().equals("nat"))
       || (type.hasTypeInfo() && (
+        type.getTypeInfo().getFullName().equals("ScalarValues.Integer") ||
         type.getTypeInfo().getFullName().equals("ScalarValues.Natural") ||
         type.getTypeInfo().getFullName().equals("ScalarValues.Positive"))
     );

--- a/language/src/main/java/de/monticore/lang/sysmlv2/types3/util/SysMLSymTypeBoxingVisitor.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/types3/util/SysMLSymTypeBoxingVisitor.java
@@ -27,9 +27,6 @@ public class SysMLSymTypeBoxingVisitor extends de.monticore.types3.util.SymTypeB
     objectBoxMap_temp.put("String", "ScalarValues.String");
     sysMLObjectBoxMap = Collections.unmodifiableMap(objectBoxMap_temp);
 
-    /* Können Optional nicht boxen.
-     * Stattdessen Optional<T> mit T[0..1] darstellen?
-     */
     Map<String, String> genericBoxMap_temp = new HashMap<>();
     genericBoxMap_temp.put("Set", "Collections.Set");
     genericBoxMap_temp.put("List", "Collections.List");

--- a/language/src/main/java/de/monticore/lang/sysmlv2/types3/util/SysMLSymTypeBoxingVisitor.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/types3/util/SysMLSymTypeBoxingVisitor.java
@@ -8,14 +8,33 @@ public class SysMLSymTypeBoxingVisitor extends de.monticore.types3.util.SymTypeB
 
   protected static final Map<String, String> sysMLPrimitiveBoxMap;
   protected static final Map<String, String> sysMLObjectBoxMap;
+  protected static final Map<String, String> sysMLGenericBoxMap;
 
   static {
-    Map<String, String> primitiveBoxMap_temp = new HashMap<>(primitiveBoxMap);
+    Map<String, String> primitiveBoxMap_temp = new HashMap<>();
+    primitiveBoxMap_temp.put("boolean", "ScalarValues.Boolean");
+    primitiveBoxMap_temp.put("byte", "ScalarValues.Integer");
+    primitiveBoxMap_temp.put("char", "ScalarValues.Natural");
+    primitiveBoxMap_temp.put("double", "ScalarValues.Rational");
+    primitiveBoxMap_temp.put("float", "ScalarValues.Rational");
+    primitiveBoxMap_temp.put("int", "ScalarValues.Integer");
+    primitiveBoxMap_temp.put("long", "ScalarValues.Integer");
+    primitiveBoxMap_temp.put("short", "ScalarValues.Integer");
     primitiveBoxMap_temp.put("nat", "ScalarValues.Natural");
     sysMLPrimitiveBoxMap = Collections.unmodifiableMap(primitiveBoxMap_temp);
 
-    Map<String, String> objectBoxMap_temp = new HashMap<>(objectBoxMap);
+    Map<String, String> objectBoxMap_temp = new HashMap<>();
+    objectBoxMap_temp.put("String", "ScalarValues.String");
     sysMLObjectBoxMap = Collections.unmodifiableMap(objectBoxMap_temp);
+
+    /* Können Optional nicht boxen.
+     * Stattdessen Optional<T> mit T[0..1] darstellen?
+     */
+    Map<String, String> genericBoxMap_temp = new HashMap<>();
+    genericBoxMap_temp.put("Set", "Collections.Set");
+    genericBoxMap_temp.put("List", "Collections.List");
+    genericBoxMap_temp.put("Map", "Collections.Map");
+    sysMLGenericBoxMap = Collections.unmodifiableMap(genericBoxMap_temp);
   }
 
   @Override
@@ -26,5 +45,10 @@ public class SysMLSymTypeBoxingVisitor extends de.monticore.types3.util.SymTypeB
   @Override
   public Map<String, String> getObjectBoxMap() {
     return sysMLObjectBoxMap;
+  }
+
+  @Override
+  public Map<String, String> getGenericBoxMap() {
+    return sysMLGenericBoxMap;
   }
 }

--- a/language/src/main/java/de/monticore/lang/sysmlv2/types3/util/SysMLSymTypeBoxingVisitor.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/types3/util/SysMLSymTypeBoxingVisitor.java
@@ -4,6 +4,10 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Verändert die Standard-Boxmap, so dass nicht mehr nach java.lang.* geboxt
+ * wird, sondern zu den KerML-ELemente aus ScalarValues, Collections, etc.
+ */
 public class SysMLSymTypeBoxingVisitor extends de.monticore.types3.util.SymTypeBoxingVisitor {
 
   protected static final Map<String, String> sysMLPrimitiveBoxMap;

--- a/language/src/test/java/typecheck/CompareTypesTest.java
+++ b/language/src/test/java/typecheck/CompareTypesTest.java
@@ -10,6 +10,7 @@ import de.se_rwth.commons.logging.Log;
 import de.se_rwth.commons.logging.LogStub;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -36,13 +37,6 @@ public class CompareTypesTest {
     tool.init();
   }
 
-  /*
-   * String und nat benötigen boxing, da es für nat keinen java.lang.Natural gibt.
-   * Für String gilt, Objekte-Kompatibel, wenn eine der Bedingungen erfüllt ist:
-   * - den gleichen Namen und die gleichen Args haben
-   * - Super/Sub-types voneinander sein
-   * - zu den gleichen Typen oder zu Super/Sub-types voneinander geboxed werden
-   */
   @ParameterizedTest
   @ValueSource(strings = {
       "attribute target : boolean; attribute source : ScalarValues::Boolean;",
@@ -55,10 +49,25 @@ public class CompareTypesTest {
       "attribute target : double; attribute source : ScalarValues::Real;",
       "attribute target : int; attribute source : ScalarValues::Positive;",
       "attribute target : ScalarValues::Positive; attribute source : ScalarValues::Natural;",
-//      "attribute target : ScalarValues::String; attribute source : String;",
+      "attribute target : ScalarValues::String; attribute source : String;",
       "attribute target : ScalarValues::Natural; attribute source : nat;"
   })
   public void test4CompatibleTypes(String targetAndSource) throws IOException {
+    var type = typeOfConstraintExpression(targetAndSource);
+
+    assertTrue(type.isPrimitive());
+    assertThat(type.printFullName()).isEqualTo("boolean");
+    assertTrue(Log.getFindings().isEmpty());
+  }
+
+  @Disabled
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "attribute target : Set<ScalarValues::String>; attribute source : Collections::Set<ScalarValues::String>;",
+      "attribute target : List<ScalarValues::String>; attribute source : Collections::List<ScalarValues::String>;",
+      "attribute target : Map<ScalarValues::String, ScalarValues::Integer>; attribute source : Collections::Map<ScalarValues::String, ScalarValues::Integer>;",
+  })
+  public void test4CompatibleGenericTypes(String targetAndSource) throws IOException {
     var type = typeOfConstraintExpression(targetAndSource);
 
     assertTrue(type.isPrimitive());


### PR DESCRIPTION
## Changed

- Boxe primitive Typen, Objekt-Typ String und generische Typen zu den entsprechenden ScalarValues Symbolen statt java.lang-Symbolen
  * Entferne dabei die zuvor geladenen java.lang Symbole aus #212

## Anmerkungen
- Generische Typen zu ScalarValues boxen scheitert noch aufgrund von fehlenen KerML-Symbolen (Collections.kerml)
- Generischer Typ `Optional` wird nicht geboxed
