### PR TITLE
7.8.91: Refactor SysMLBuiltInTypeRelations

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,4 +25,4 @@ assertj_version    = 3.21.0
 junit_version      = 5.8.2
 
 # Version of published artifacts
-version            = 7.8.90
+version            = 7.8.91

--- a/language/src/main/java/de/monticore/lang/sysmlv2/types3/SysMLBuiltInTypeRelations.java
+++ b/language/src/main/java/de/monticore/lang/sysmlv2/types3/SysMLBuiltInTypeRelations.java
@@ -10,24 +10,6 @@ import de.monticore.types.check.SymTypeExpression;
 public class SysMLBuiltInTypeRelations extends de.monticore.types3.util.BuiltInTypeRelations{
 
   @Override
-  public boolean isNumericType(SymTypeExpression type) {
-    return super.isNumericType(type) || isIntegralType(type) || isDouble(type);
-  }
-
-  @Override
-  public boolean isIntegralType(SymTypeExpression type) {
-    return super.isIntegralType(type)
-        || (type.isPrimitive()
-          && type.asPrimitive().getPrimitiveName().equals("nat"))
-        || (type.hasTypeInfo()
-          && (
-            type.getTypeInfo().getFullName().equals("ScalarValues.Integer") ||
-            type.getTypeInfo().getFullName().equals("ScalarValues.Natural") ||
-            type.getTypeInfo().getFullName().equals("ScalarValues.Positive"))
-    );
-  }
-
-  @Override
   public boolean isBoolean(SymTypeExpression type) {
     return super.isBoolean(type) ||
       (type.hasTypeInfo() &&
@@ -36,32 +18,33 @@ public class SysMLBuiltInTypeRelations extends de.monticore.types3.util.BuiltInT
 
   @Override
   public boolean isDouble(SymTypeExpression type) {
-    return super.isDouble(type)
-      || (type.hasTypeInfo() && (
-        type.getTypeInfo().getFullName().equals("ScalarValues.Real") ||
-        type.getTypeInfo().getFullName().equals("ScalarValues.Rational"))
-    );
+    return super.isDouble(type) ||
+    (type.isObjectType() && (
+      type.printFullName().equals("ScalarValues.Real") ||
+      type.printFullName().equals("ScalarValues.Rational")
+    ));
   }
 
   @Override
   public boolean isInt(SymTypeExpression type) {
-    return super.isInt(type)
-      || (type.isPrimitive()
-        && type.asPrimitive().getPrimitiveName().equals("nat"))
-      || (type.hasTypeInfo() && (
-        type.getTypeInfo().getFullName().equals("ScalarValues.Integer") ||
-        type.getTypeInfo().getFullName().equals("ScalarValues.Natural") ||
-        type.getTypeInfo().getFullName().equals("ScalarValues.Positive"))
-    );
+    return super.isInt(type) || isNat(type) ||
+      (type.isObjectType() &&
+        type.printFullName().equals("ScalarValues.Integer"));
   }
 
   @Override
   public boolean isString(SymTypeExpression type) {
-    boolean isScalarValuesString = false;
-    if (type.isObjectType()) {
-      isScalarValuesString = type.hasTypeInfo()
-        && (type.getTypeInfo().getFullName().equals("ScalarValues.String"));
+    return super.isString(type) || (type.isObjectType() &&
+      type.printFullName().equals("ScalarValues.String"));
+  }
+
+  public boolean isNat(SymTypeExpression type) {
+    if (type.isPrimitive()) {
+      return type.printFullName().equals("nat");
+    } else {
+    return (type.isObjectType() && (
+      type.printFullName().equals("ScalarValues.Natural") ||
+      type.printFullName().equals("ScalarValues.Positive")));
     }
-    return super.isString(type) || isScalarValuesString;
   }
 }


### PR DESCRIPTION
## Changed
- Refactor #226: Wende kommentierte Vorschläge an und entferne unnötige Overrides.
  * `ScalarValues::Natural` und `nat` werden durch das Einbinden von `isNat` in `isInt` automatisch auch Integral und Numeric. Dadurch entfällt ein Override von jeweils `isIntegral` und `isNumeric`. 
  Das Einbinden hat den zusätzlichen Grund, dass der `SymTypeCompatibilityCalculator`, in seiner Berechnung von numerischer Kompatiblität, explizit nach den Typen fragt. Dabei taucht `nat` und somit `isNat` aber nicht auf, kann aber von `isInt` abgedeckt werden. 
  Alternativ könnte man `boxedPrimitiveConstrainSubTypeOf` überschreiben.